### PR TITLE
fix: 修复货币战争部分问题，添加部分特性

### DIFF
--- a/Command/Command/Cmd/CommandGrid.cs
+++ b/Command/Command/Cmd/CommandGrid.cs
@@ -40,18 +40,16 @@ public class CommandGrid : ICommand
             return;
         }
 
+        if (!inst.TryAllocBenchPos(out var pos))
+        {
+            await arg.SendMsg(I18NManager.Translate("Game.Command.Notice.InvalidArguments"));
+            return;
+        }
+
         var uniqueId = inst.AllocRoleUniqueId();
         inst.RoleByUniqueId[uniqueId] = roleId;
         inst.RoleStarByUniqueId[uniqueId] = star;
-
-        uint pos = 0;
-        foreach (var p in new uint[] { 14, 15, 16, 17, 18, 6, 7, 8, 9, 10, 11, 12, 13 })
-        {
-            if (inst.UniqueIdByPos.ContainsKey(p)) continue;
-            pos = p;
-            break;
-        }
-        if (pos > 0) inst.UniqueIdByPos[pos] = uniqueId;
+        inst.UniqueIdByPos[pos] = uniqueId;
 
         var roleInfo = new GridGameRoleInfo
         {

--- a/GameServer/Game/Battle/BattleInstance.cs
+++ b/GameServer/Game/Battle/BattleInstance.cs
@@ -90,6 +90,11 @@ public class BattleInstance(PlayerInstance player, LineupInfo lineup, List<Stage
     public GridFightInstance? GridFightContext { get; set; }
     public CalyxOverrideContext? CalyxOverride { get; set; }
 
+    /// <summary>
+    /// Cached random seed so repeated battle-info queries stay stable for the same encounter.
+    /// </summary>
+    public uint? LogicRandomSeed { get; set; }
+
     public delegate ValueTask OnBattleEndDelegate(BattleInstance battle, PVEBattleResultCsReq req);
 
     public event OnBattleEndDelegate? OnBattleEnd;
@@ -242,7 +247,7 @@ public class BattleInstance(PlayerInstance player, LineupInfo lineup, List<Stage
             WorldLevel = (uint)WorldLevel,
             RoundsLimit = (uint)RoundLimit,
             StageId = (uint)StageId,
-            LogicRandomSeed = (uint)Random.Shared.Next()
+            LogicRandomSeed = LogicRandomSeed ?? (uint)Random.Shared.Next()
         };
 
         if (MagicInfo != null) proto.BattleRogueMagicInfo = MagicInfo;
@@ -321,14 +326,15 @@ public class BattleInstance(PlayerInstance player, LineupInfo lineup, List<Stage
             proto.BattleTargetInfo.Add((uint)i, battleTargetEntry);
         }
 
-        
-        foreach (var buff in GameData.AvatarGlobalBuffConfigData.Values)
-            if (Player.AvatarManager!.GetFormalAvatar(buff.AvatarID) != null)
-                
-                Buffs.Add(new MazeBuff(buff.MazeBuffID, 1, -1)
-                {
-                    WaveFlag = -1
-                });
+        if (GridFightContext == null)
+        {
+            foreach (var buff in GameData.AvatarGlobalBuffConfigData.Values)
+                if (Player.AvatarManager!.GetFormalAvatar(buff.AvatarID) != null)
+                    Buffs.Add(new MazeBuff(buff.MazeBuffID, 1, -1)
+                    {
+                        WaveFlag = -1
+                    });
+        }
 
         foreach (var buff in Buffs)
         {

--- a/GameServer/Game/GridFight/Battle/GridFightBattleModule.cs
+++ b/GameServer/Game/GridFight/Battle/GridFightBattleModule.cs
@@ -1,6 +1,8 @@
 using March7thHoney.Data;
+using March7thHoney.Data.Excel;
 using March7thHoney.Database.Lineup;
 using March7thHoney.GameServer.Game.Battle;
+using March7thHoney.GameServer.Game.GridFight;
 using March7thHoney.GameServer.Game.Player;
 using March7thHoney.Proto;
 using LineupInfo = March7thHoney.Database.Lineup.LineupInfo;
@@ -14,12 +16,7 @@ public static class GridFightBattleModule
         if (player.BattleInstance != null)
             return player.BattleInstance;
 
-        var encounter = GridFightLevelResolver.Resolve(gridFightInstance);
-        var ok = GameData.StageConfigData.TryGetValue((int)encounter.StageId, out var stageConfig);
-        if (!ok)
-            ok = GameData.StageConfigData.TryGetValue((int)GridFightLevelResolver.UnifiedStageId, out stageConfig);
-        if (!ok)
-            stageConfig = GameData.StageConfigData.Values.FirstOrDefault();
+        var stageConfig = ResolveStageConfig(gridFightInstance);
         if (stageConfig == null)
             return null;
 
@@ -38,10 +35,29 @@ public static class GridFightBattleModule
         var battle = new BattleInstance(player, tempLineup, [stageConfig])
         {
             WorldLevel = player.Data.WorldLevel,
-            GridFightContext = gridFightInstance
+            GridFightContext = gridFightInstance,
+            LogicRandomSeed = (uint)Random.Shared.Next()
         };
 
         player.BattleInstance = battle;
+        player.QuestManager?.OnBattleStart(battle);
         return battle;
+    }
+
+    private static StageConfigExcel? ResolveStageConfig(GridFightInstance gridFightInstance)
+    {
+        var configuredStageId = gridFightInstance.BattleComponent.StageId;
+        if (configuredStageId > 0
+            && GameData.StageConfigData.TryGetValue((int)configuredStageId, out var configuredStage))
+            return configuredStage;
+
+        var encounter = GridFightLevelResolver.Resolve(gridFightInstance);
+        if (GameData.StageConfigData.TryGetValue((int)encounter.StageId, out var encounterStage))
+            return encounterStage;
+
+        if (GameData.StageConfigData.TryGetValue((int)GridFightLevelResolver.UnifiedStageId, out var unifiedStage))
+            return unifiedStage;
+
+        return GameData.StageConfigData.Values.FirstOrDefault();
     }
 }

--- a/GameServer/Game/GridFight/Battle/GridFightBattleProtoBuilder.cs
+++ b/GameServer/Game/GridFight/Battle/GridFightBattleProtoBuilder.cs
@@ -1,6 +1,7 @@
 using March7thHoney.Data;
 using March7thHoney.Database.Avatar;
 using March7thHoney.GameServer.Game.Battle;
+using March7thHoney.GameServer.Game.GridFight;
 using March7thHoney.GameServer.Game.Lineup;
 using March7thHoney.GameServer.Game.Player;
 using March7thHoney.Proto;
@@ -18,30 +19,39 @@ public static class GridFightBattleProtoBuilder
 
         var collection = new PlayerDataCollection(player.Data, player.InventoryManager!.Data, battle.Lineup);
 
-        foreach (var (roleId, _) in inst.ResolveForegroundRoles())
+        foreach (var (roleKey, pos) in inst.ResolveForegroundRoles())
         {
-            var resolved = ResolveBattleAvatar(player, roleId);
+            var resolved = ResolveForegroundBattleAvatar(player, roleKey);
             var avatar = resolved.Avatar;
             if (avatar == null) continue;
-            proto.BattleAvatarList.Add(avatar.ToBattleProto(collection, resolved.AvatarType));
-            foregroundData.Add(new AvatarLineupData(avatar, resolved.AvatarType));
+
+            var battleAvatar = avatar.ToBattleProto(collection, AvatarType.AvatarTrialType);
+            battleAvatar.Index = pos;
+            proto.BattleAvatarList.Add(battleAvatar);
+            foregroundData.Add(new AvatarLineupData(avatar, AvatarType.AvatarTrialType));
         }
 
         proto.MonsterWaveList.Clear();
-        
-        
+
+        var stageId = inst.BattleComponent.StageId > 0 ? inst.BattleComponent.StageId : enc.StageId;
+        var monsterSpecs = inst.BattleComponent.MonsterIds.Count > 0
+            ? inst.BattleComponent.MonsterIds.Select(id => new GridFightMonsterSpec(id, 1u, [])).ToList()
+            : enc.Monsters;
+
+        proto.StageId = stageId;
+
         var monsterWorldLevel = (uint)Math.Max(1, battle.Player.Data.WorldLevel - 1);
         var wave = new SceneMonsterWave
         {
-            BattleStageId = (uint)battle.StageId,
+            BattleStageId = stageId,
             BattleWaveId = 1,
             MonsterParam = new SceneMonsterWaveParam
             {
-                EliteGroup = enc.EliteGroupId,
+                EliteGroup = inst.ResolveEliteGroupForCurrentSection(),
                 BDCCEFHMFHO = monsterWorldLevel
             }
         };
-        foreach (var spec in enc.Monsters)
+        foreach (var spec in monsterSpecs)
         {
             var sceneMonster = new SceneMonster
             {
@@ -60,12 +70,17 @@ public static class GridFightBattleProtoBuilder
                     Num = 1
                 });
             }
+
             wave.MonsterList.Add(sceneMonster);
         }
+
         proto.MonsterWaveList.Add(wave);
 
         foreach (var buffId in enc.BindingBuffs)
+        {
+            if (battle.Buffs.Any(b => b.BuffID == (int)buffId)) continue;
             battle.Buffs.Add(new MazeBuff((int)buffId, 1, -1) { WaveFlag = -1 });
+        }
 
         foreach (var beId in enc.BattleEvents)
             battle.BattleEvents.TryAdd((int)beId, new BattleEventInstance((int)beId, 0, 100000));
@@ -73,17 +88,41 @@ public static class GridFightBattleProtoBuilder
         return foregroundData;
     }
 
-    internal static (BaseAvatarInfo? Avatar, AvatarType AvatarType) ResolveBattleAvatar(PlayerInstance player, uint roleId)
+    /// <summary>
+    /// Resolves a foreground board role as a Grid Fight trial avatar (pos 1-4).
+    /// </summary>
+    internal static (BaseAvatarInfo? Avatar, AvatarType AvatarType) ResolveForegroundBattleAvatar(
+        PlayerInstance player, uint roleKey)
     {
-        if (!GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var basicInfo))
+        var basicInfo = GridFightRoleLookup.Find(roleKey);
+        if (basicInfo == null)
             return (null, AvatarType.AvatarTrialType);
+
+        var trial = player.AvatarManager?.GetTrialAvatarByWorldLevel(
+            (int)basicInfo.SpecialAvatarID, player.Data.WorldLevel);
+        if (trial != null)
+            return (trial, AvatarType.AvatarTrialType);
+
+        var formal = player.AvatarManager?.GetFormalAvatar((int)basicInfo.AvatarID);
+        return (formal, AvatarType.AvatarTrialType);
+    }
+
+    /// <summary>
+    /// Resolves a background board role for Grid Fight battle payloads (pos 5-13).
+    /// </summary>
+    internal static (BaseAvatarInfo? Avatar, AvatarType AvatarType) ResolveBackgroundBattleAvatar(
+        PlayerInstance player, uint roleKey)
+    {
+        var basicInfo = GridFightRoleLookup.Find(roleKey);
+        if (basicInfo == null)
+            return (null, AvatarType.AvatarGridFightType);
 
         var formal = player.AvatarManager?.GetFormalAvatar((int)basicInfo.AvatarID);
         if (formal != null)
-            return (formal, AvatarType.AvatarFormalType);
+            return (formal, AvatarType.AvatarGridFightType);
 
-        var trial = player.AvatarManager?.GetTrialAvatarByWorldLevel((int)basicInfo.SpecialAvatarID, player.Data.WorldLevel);
-        return (trial, AvatarType.AvatarTrialType);
+        var trial = player.AvatarManager?.GetTrialAvatarByWorldLevel(
+            (int)basicInfo.SpecialAvatarID, player.Data.WorldLevel);
+        return (trial, AvatarType.AvatarGridFightType);
     }
-
 }

--- a/GameServer/Game/GridFight/Battle/GridFightLevelResolver.cs
+++ b/GameServer/Game/GridFight/Battle/GridFightLevelResolver.cs
@@ -1,5 +1,6 @@
 using March7thHoney.Data;
 using March7thHoney.Data.Excel;
+using March7thHoney.GameServer.Game.GridFight;
 
 namespace March7thHoney.GameServer.Game.GridFight.Battle;
 
@@ -253,7 +254,8 @@ public static class GridFightLevelResolver
                      .Select(uid => inst.RoleByUniqueId.GetValueOrDefault(uid))
                      .Where(r => r != 0))
         {
-            if (!GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var info)) continue;
+            var info = GridFightRoleLookup.Find(roleId);
+            if (info == null) continue;
             foreach (var t in info.TraitList) set.Add(t);
         }
         return set.ToList();

--- a/GameServer/Game/GridFight/Battle/GridFightRoleLookup.cs
+++ b/GameServer/Game/GridFight/Battle/GridFightRoleLookup.cs
@@ -1,0 +1,64 @@
+using March7thHoney.Data;
+using March7thHoney.Data.Excel;
+
+namespace March7thHoney.GameServer.Game.GridFight.Battle;
+
+/// <summary>
+/// Resolves GridFight role config entries. Runtime maps may store either internal role ID or AvatarID.
+/// </summary>
+public static class GridFightRoleLookup
+{
+    /// <summary>
+    /// Finds role basic info by internal role ID or AvatarID.
+    /// </summary>
+    public static GridFightRoleBasicInfoExcel? Find(uint roleKey)
+    {
+        if (roleKey == 0) return null;
+        if (GameData.GridFightRoleBasicInfoData.TryGetValue(roleKey, out var byId))
+            return byId;
+
+        foreach (var role in GameData.GridFightRoleBasicInfoData.Values)
+        {
+            if (role.AvatarID == roleKey) return role;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Tries to resolve role basic info by internal role ID or AvatarID.
+    /// </summary>
+    public static bool TryFind(uint roleKey, out GridFightRoleBasicInfoExcel basicInfo)
+    {
+        var found = Find(roleKey);
+        if (found == null)
+        {
+            basicInfo = null!;
+            return false;
+        }
+
+        basicInfo = found;
+        return true;
+    }
+
+    /// <summary>
+    /// Converts a stored role key to the avatar ID used in battle payloads.
+    /// </summary>
+    public static uint ToAvatarId(uint roleKey)
+    {
+        return Find(roleKey)?.AvatarID ?? roleKey;
+    }
+
+    /// <summary>
+    /// Converts a stored role key to the internal GridFight role ID.
+    /// </summary>
+    public static uint ToRoleId(uint roleKey)
+    {
+        return Find(roleKey)?.ID ?? roleKey;
+    }
+
+    /// <summary>
+    /// Returns the role ID used in GridGameRoleInfo sync payloads (internal ID, e.g. 11011 for Bronya path 1).
+    /// </summary>
+    public static uint ToSyncRoleId(uint roleKey) => ToRoleId(roleKey);
+}

--- a/GameServer/Game/GridFight/GridFightCyreneSpecialShopService.cs
+++ b/GameServer/Game/GridFight/GridFightCyreneSpecialShopService.cs
@@ -1,0 +1,118 @@
+using March7thHoney.Data;
+using March7thHoney.GameServer.Game.GridFight.Battle;
+using March7thHoney.Proto;
+
+namespace March7thHoney.GameServer.Game.GridFight;
+
+/// <summary>
+/// 三星昔涟进入出战席后触发一次专属免费诗篇商店。（但是好像没什么用？）
+/// </summary>
+public static class GridFightCyreneSpecialShopService
+{
+    private const uint CyreneAvatarId = 1415;
+    private const uint ThreeStar = 3;
+    private const uint TraitGoodsPrefix = 3004;
+    private const uint RoleGoodsPrefix = 1415;
+    private const uint BattlefieldPosMin = 1;
+    private const uint BattlefieldPosMax = 13;
+    private const int SpecialShopSlotCount = 5;
+
+    private static readonly uint[] PreferredTraitGoodsIds = [300401, 300402, 300403, 300404, 300405];
+    private static readonly uint[] FallbackRoleGoodsIds = [141501, 141502, 141503, 141504, 141505];
+
+    /// <summary>
+    /// 若本局未触发且出战席存在三星昔涟，则刷新为免费专属诗篇商店。
+    /// </summary>
+    public static bool TryApplySpecialShop(GridFightInstance inst)
+    {
+        if (inst.CyreneSpecialShopTriggered)
+            return false;
+        if (!TryGetThreeStarCyreneBattlefieldRole(inst, out _, out _))
+            return false;
+
+        var goodsIds = ResolveSpecialGoodsIds();
+        if (goodsIds.Count == 0)
+            return false;
+
+        inst.ShopGoods.Clear();
+        inst.ShopRollCounter++;
+        inst.LastBoughtShopIndex = -1;
+        inst.LastBoughtUniqueId = 0;
+
+        foreach (var goodsId in goodsIds)
+        {
+            inst.ShopGoods.Add(new GridFightShopGoodsInfo
+            {
+                ShopGoodsPrice = 0,
+                SpecialGoodsInfo = new GridFightSpecialGoodsInfo { SpecialGoodsId = goodsId }
+            });
+        }
+
+        inst.CyreneSpecialShopTriggered = true;
+        return true;
+    }
+
+    /// <summary>
+    /// 解析客户端资源中真实存在的诗篇 augment ID（优先 300401-405，不足则补 141501-505）。
+    /// </summary>
+    public static List<uint> ResolveSpecialGoodsIds()
+    {
+        var ids = new List<uint>();
+        var seen = new HashSet<uint>();
+
+        void AddIfValid(uint id)
+        {
+            if (id == 0 || !seen.Add(id))
+                return;
+            if (!GameData.GridFightAugmentData.ContainsKey(id))
+                return;
+            ids.Add(id);
+        }
+
+        foreach (var id in PreferredTraitGoodsIds)
+            AddIfValid(id);
+        if (ids.Count >= SpecialShopSlotCount)
+            return ids.Take(SpecialShopSlotCount).ToList();
+
+        foreach (var id in FallbackRoleGoodsIds)
+            AddIfValid(id);
+        if (ids.Count >= SpecialShopSlotCount)
+            return ids.Take(SpecialShopSlotCount).ToList();
+
+        foreach (var id in GameData.GridFightAugmentData.Keys.OrderBy(x => x))
+        {
+            if (id / 100 != TraitGoodsPrefix && id / 100 != RoleGoodsPrefix)
+                continue;
+            AddIfValid(id);
+            if (ids.Count >= SpecialShopSlotCount)
+                break;
+        }
+
+        return ids.Take(SpecialShopSlotCount).ToList();
+    }
+
+    /// <summary>
+    /// 获取出战席三星昔涟的 uniqueId 与 pos。
+    /// </summary>
+    public static bool TryGetThreeStarCyreneBattlefieldRole(GridFightInstance inst, out uint uniqueId, out uint pos)
+    {
+        uniqueId = 0;
+        pos = 0;
+        foreach (var (slot, uid) in inst.UniqueIdByPos)
+        {
+            if (slot is < BattlefieldPosMin or > BattlefieldPosMax || uid == 0)
+                continue;
+            if (!inst.RoleByUniqueId.TryGetValue(uid, out var roleKey))
+                continue;
+            if (GridFightRoleLookup.ToAvatarId(roleKey) != CyreneAvatarId)
+                continue;
+            if (inst.RoleStarByUniqueId.GetValueOrDefault(uid, 1u) != ThreeStar)
+                continue;
+            uniqueId = uid;
+            pos = slot;
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/GameServer/Game/GridFight/GridFightHeadPlayerService.cs
+++ b/GameServer/Game/GridFight/GridFightHeadPlayerService.cs
@@ -1,0 +1,232 @@
+using March7thHoney.GameServer.Game.GridFight.Battle;
+using March7thHoney.GameServer.Server;
+using March7thHoney.GameServer.Server.Packet.Send.GridFight;
+using March7thHoney.Kcp;
+using March7thHoney.Proto;
+
+namespace March7thHoney.GameServer.Game.GridFight;
+
+/// <summary>
+/// 银狼 LV.999 独立羁绊「头号玩家」：15061/15062/15063 进入出战席时解锁羁绊栏 GM 控制台。（然而并未生效）
+/// </summary>
+public static class GridFightHeadPlayerService
+{
+    private const uint HeadPlayerTraitId = 3006;
+    private const uint HeadPlayerGmAugmentId = 150601;
+    private const uint BattlefieldPosMin = 1;
+    private const uint BattlefieldPosMax = 13;
+
+    private static readonly uint[] HeadPlayerRoleIds = [15061, 15062, 15063];
+
+    /// <summary>
+    /// 若出战席存在尚未激活 GM 控制台的银狼角色，则绑定 augment 150601 并构建 sync。
+    /// </summary>
+    public static bool TryActivate(GridFightInstance inst, out GridFightSyncUpdateResultScNotify? notify)
+    {
+        notify = null;
+        if (!TryGetBattlefieldHeadPlayerRole(inst, out var uniqueId, out _))
+            return false;
+        if (inst.HeadPlayerActivatedUniqueIds.Contains(uniqueId))
+            return false;
+
+        ApplyGmConsoleState(inst, uniqueId);
+        notify = BuildGmConsoleUnlockNotify(inst, uniqueId);
+        return true;
+    }
+
+    /// <summary>
+    /// 检测出战席银狼并下发 GM 控制台解锁 sync（8456）。
+    /// </summary>
+    public static async System.Threading.Tasks.Task TrySendActivationAsync(Connection connection, GridFightInstance inst)
+    {
+        if (!TryGetBattlefieldHeadPlayerRole(inst, out var uniqueId, out _))
+            return;
+
+        if (!inst.HeadPlayerActivatedUniqueIds.Contains(uniqueId))
+            ApplyGmConsoleState(inst, uniqueId);
+
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(
+            BuildGmConsoleUnlockNotify(inst, uniqueId)));
+    }
+
+    /// <summary>
+    /// 处理 TraitAction 确认（兼容历史 pending）；直接完成 GM 控制台激活，不打开其他 UI。
+    /// </summary>
+    public static async System.Threading.Tasks.Task HandleTraitActionAsync(
+        Connection connection,
+        GridFightInstance inst,
+        uint ackPos,
+        GridFightTraitActionResult? result)
+    {
+        if (inst.PendingAction?.TraitAction == null)
+        {
+            await ResyncTraitPending(connection, inst, ackPos);
+            return;
+        }
+
+        var pending = inst.PendingAction.TraitAction;
+        var uniqueId = pending.GridFightTraitMemberUniqueIdList.Count > 0
+            ? pending.GridFightTraitMemberUniqueIdList[0]
+            : 0u;
+
+        if (result != null && result.UniqueId > 0)
+            uniqueId = result.UniqueId;
+
+        if (uniqueId > 0
+            && inst.RoleByUniqueId.TryGetValue(uniqueId, out var roleKey)
+            && IsHeadPlayerRole(GridFightRoleLookup.ToRoleId(roleKey)))
+        {
+            ApplyGmConsoleState(inst, uniqueId);
+        }
+
+        var nextPos = ackPos + 1;
+        inst.QueuePosition = nextPos;
+        inst.PendingAction = new GridFightPendingAction
+        {
+            QueuePosition = nextPos,
+            ReturnPreparationAction = new GridFightReturnPreparationActionInfo()
+        };
+
+        await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
+
+        var sync = new GridFightSyncUpdateResultScNotify();
+
+        if (uniqueId > 0)
+            sync.SyncResultDataList.Add(BuildGmConsoleRoleSyncSection(inst, uniqueId));
+
+        var finishSec = new GridFightSyncResultData();
+        finishSec.UpdateDynamicList.Add(new GridFightSyncData { FinishPendingActionPos = ackPos });
+        finishSec.UpdateDynamicList.Add(new GridFightSyncData { SyncLockInfo = new GridFightLockInfo() });
+        sync.SyncResultDataList.Add(finishSec);
+
+        var nextSec = new GridFightSyncResultData();
+        nextSec.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            SyncLockInfo = new GridFightLockInfo
+            {
+                LockReason = GridFightLockReason.DfofffceffoKjmjdbjmbmc,
+                LockType = GridFightLockType.PjbmhhnlclbEhfhdgpocnh
+            }
+        });
+        nextSec.UpdateDynamicList.Add(new GridFightSyncData { PendingAction = inst.PendingAction });
+        sync.SyncResultDataList.Add(nextSec);
+
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
+    }
+
+    /// <summary>
+    /// 判断 roleId 是否属于银狼 LV.999 系列（15061/15062/15063）。
+    /// </summary>
+    public static bool IsHeadPlayerRole(uint roleId)
+    {
+        roleId = GridFightRoleLookup.ToRoleId(roleId);
+        return HeadPlayerRoleIds.Contains(roleId);
+    }
+
+    /// <summary>
+    /// 查找出战席上的银狼 LV.999 角色（任意星级）。
+    /// </summary>
+    public static bool TryGetBattlefieldHeadPlayerRole(GridFightInstance inst, out uint uniqueId, out uint roleId)
+    {
+        uniqueId = 0;
+        roleId = 0;
+
+        foreach (var (pos, uid) in inst.UniqueIdByPos.OrderBy(kv => kv.Key))
+        {
+            if (pos < BattlefieldPosMin || pos > BattlefieldPosMax || uid == 0)
+                continue;
+            if (!inst.RoleByUniqueId.TryGetValue(uid, out var roleKey))
+                continue;
+
+            var internalRoleId = GridFightRoleLookup.ToRoleId(roleKey);
+            if (!IsHeadPlayerRole(internalRoleId))
+                continue;
+
+            uniqueId = uid;
+            roleId = internalRoleId;
+            return true;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// 写入 GM 控制台状态：标记已激活，并绑定 augment 150601。
+    /// </summary>
+    public static void ApplyGmConsoleState(GridFightInstance inst, uint uniqueId)
+    {
+        inst.HeadPlayerActivatedUniqueIds.Add(uniqueId);
+        inst.BindRoleAugment(uniqueId, HeadPlayerGmAugmentId);
+    }
+
+    /// <summary>
+    /// 构建 GM 控制台解锁 notify（含 augment 150601 与 BAODHPCOJLH 绑定 sync）。
+    /// </summary>
+    private static GridFightSyncUpdateResultScNotify BuildGmConsoleUnlockNotify(GridFightInstance inst, uint uniqueId)
+    {
+        var notify = new GridFightSyncUpdateResultScNotify();
+        notify.SyncResultDataList.Add(BuildGmConsoleRoleSyncSection(inst, uniqueId));
+        return notify;
+    }
+
+    /// <summary>
+    /// 构建 GM 控制台角色级 sync 段（HLFBBANMJDJ + UpdateRoleInfo + GridGameAugmentUpdate + BAODHPCOJLH）。
+    /// </summary>
+    private static GridFightSyncResultData BuildGmConsoleRoleSyncSection(GridFightInstance inst, uint uniqueId)
+    {
+        var roleSec = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpLfnkhcbhmpd };
+        roleSec.SyncEffectParamList.Add(HeadPlayerTraitId);
+        roleSec.SyncEffectParamList.Add(HeadPlayerGmAugmentId);
+        roleSec.UpdateDynamicList.Add(new GridFightSyncData { HLFBBANMJDJ = uniqueId });
+        roleSec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = inst.BuildGridGameRoleInfo(uniqueId) });
+        roleSec.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            GridGameAugmentUpdate = new GridFightGameAugmentUpdate
+            {
+                UpdateAugmentInfo = new GridGameAugmentInfo
+                {
+                    AugmentId = HeadPlayerGmAugmentId,
+                    NDCFBKJDPAH = true,
+                    MHMLMKDFJLN = true
+                }
+            }
+        });
+        GridFightInstance.AppendRoleAugmentBindingSync(roleSec, inst, uniqueId, HeadPlayerGmAugmentId);
+        return roleSec;
+    }
+
+    /// <summary>
+    /// 重推当前 TraitAction pending（供 PendingActionProcessor 调用）。
+    /// </summary>
+    public static System.Threading.Tasks.Task ResyncTraitPendingPublic(
+        Connection connection,
+        GridFightInstance inst,
+        uint ackPos) => ResyncTraitPending(connection, inst, ackPos);
+
+    /// <summary>
+    /// 重推当前 TraitAction pending。
+    /// </summary>
+    private static async System.Threading.Tasks.Task ResyncTraitPending(
+        Connection connection,
+        GridFightInstance inst,
+        uint ackPos)
+    {
+        await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
+        if (inst.PendingAction == null)
+            return;
+
+        var sync = new GridFightSyncUpdateResultScNotify();
+        var sec = new GridFightSyncResultData();
+        sec.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            SyncLockInfo = new GridFightLockInfo
+            {
+                LockReason = GridFightLockReason.DfofffceffoKjmjdbjmbmc,
+                LockType = GridFightLockType.PjbmhhnlclbEhfhdgpocnh
+            }
+        });
+        sec.UpdateDynamicList.Add(new GridFightSyncData { PendingAction = inst.PendingAction });
+        sync.SyncResultDataList.Add(sec);
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
+    }
+}

--- a/GameServer/Game/GridFight/GridFightInstance.cs
+++ b/GameServer/Game/GridFight/GridFightInstance.cs
@@ -1122,6 +1122,40 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     }
 
     /// <summary>
+    /// 投影仪复制角色：生成与目标同角色的 1 星副本，落点规则与购买一致（备战席优先，可升星溢出）。
+    /// </summary>
+    /// <param name="sourceUniqueId">被复制角色的 uniqueId。</param>
+    /// <param name="maxRarity">允许复制的最高费用（350105=3，350106=5）。</param>
+    public (bool ok, uint newUniqueId, uint targetPos, uint sourcePos, Retcode retcode) TryCopyRole(
+        uint sourceUniqueId,
+        uint maxRarity)
+    {
+        if (!RoleByUniqueId.TryGetValue(sourceUniqueId, out var roleKey))
+            return (false, 0, 0, 0, Retcode.RetGridFightParamNotMatch);
+
+        if (!GridFightRoleLookup.TryFind(roleKey, out var roleExcel))
+            return (false, 0, 0, 0, Retcode.RetGridFightParamNotMatch);
+
+        if (maxRarity > 0 && roleExcel.Rarity > maxRarity)
+            return (false, 0, 0, 0, Retcode.RetGridFightParamNotMatch);
+
+        const uint copyStar = 1u;
+        var sourcePos = ResolveRolePos(sourceUniqueId);
+        if (sourcePos == 0)
+            return (false, 0, 0, 0, Retcode.RetGridFightParamNotMatch);
+
+        if (!TryAcquirePurchasePos(roleKey, copyStar, out var targetPos))
+            return (false, 0, 0, sourcePos, Retcode.RetGridFightNoEmptyPos);
+
+        var newUniqueId = AllocRoleUniqueId();
+        RoleByUniqueId[newUniqueId] = roleKey;
+        RoleStarByUniqueId[newUniqueId] = copyStar;
+        UniqueIdByPos[targetPos] = newUniqueId;
+
+        return (true, newUniqueId, targetPos, sourcePos, Retcode.RetSucc);
+    }
+
+    /// <summary>
     /// 购买昔涟专属诗篇等特殊商品：仅绑定至出战席三星昔涟。
     /// </summary>
     private (bool ok, uint addedUniqueId, uint roleId, uint pos, List<GridFightPosInfo> benchMoved, bool duplicateRetry, uint purchasedAugmentId, Retcode retcode) TryBuySpecialGoods(

--- a/GameServer/Game/GridFight/GridFightInstance.cs
+++ b/GameServer/Game/GridFight/GridFightInstance.cs
@@ -400,6 +400,24 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         return added;
     }
 
+    /// <summary>
+    /// 将 3503**** 成品装备（Craftable）升级为 3504****（Radiant）；保留穿戴角色与 source。
+    /// </summary>
+    public GridFightEquipmentInfo? UpgradeCraftableEquipment(uint equipUniqueId)
+    {
+        var old = FindEquipment(equipUniqueId);
+        if (old == null) return null;
+        if (!GameData.GridFightEquipUpgradeData.TryGetValue(old.GridFightEquipmentId, out var upgradeExcel))
+            return null;
+        if (!GameData.GridFightEquipmentData.TryGetValue(old.GridFightEquipmentId, out var oldExcel)
+            || oldExcel.EquipCategory != GridFightEquipCategoryEnum.Craftable)
+            return null;
+        if (!GameData.GridFightEquipmentData.ContainsKey(upgradeExcel.UpgradeID))
+            return null;
+
+        return RollEquipment(equipUniqueId, upgradeExcel.UpgradeID, old.Source);
+    }
+
     public bool TryConsumeConsumable(uint itemId, int amount = 1)
     {
         for (var i = 0; i < amount; i++)

--- a/GameServer/Game/GridFight/GridFightInstance.cs
+++ b/GameServer/Game/GridFight/GridFightInstance.cs
@@ -18,6 +18,19 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         public List<uint> RemovedUniqueIds { get; } = new();
         public uint KeptUniqueId { get; set; }
         public uint NewStar { get; set; }
+        public uint RoleId { get; set; }
+        /// <summary>
+        /// 合成参与角色在合成前的 pos，供客户端升星特效定位。
+        /// </summary>
+        public Dictionary<uint, uint> ParticipantPosByUniqueId { get; } = new();
+        /// <summary>
+        /// 合成前各参与角色的快照（含旧星级），供升星动画 sync 使用。
+        /// </summary>
+        public Dictionary<uint, GridGameRoleInfo> PreMergeRoleSnapshots { get; } = new();
+        /// <summary>
+        /// 本次合成刚完成时的保留卡快照，避免连续合成后 finalize 读到已消耗状态。
+        /// </summary>
+        public GridGameRoleInfo? FinalKeeperRoleInfo { get; set; }
         public bool Merged => RemovedUniqueIds.Count > 0 && KeptUniqueId > 0;
     }
     public PlayerInstance Player { get; } = player;
@@ -33,7 +46,7 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     public uint BattleMaxHp { get; } = 10939;
     public uint Level { get; } = 1;
     public uint SectionId { get; set; } = 1;
-    public uint NDOCIKPLKIF { get; } = 1801;
+    public uint NDOCIKPLKIF => ResolveCombatEliteGroup();
     public uint CurrentChapterId { get; set; } = 1;
     public uint CurrentBranchId { get; set; } = 1;
     public uint RouteId { get; set; } = 1200;
@@ -54,11 +67,22 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     public Dictionary<uint, uint> RoleStarByUniqueId { get; } = new();
     public Dictionary<uint, List<uint>> EquipUniqueIdsByRoleUniqueId { get; } = new();
 
+    /// <summary>角色绑定的 augment ID（key 为角色 uniqueId）。</summary>
+    public Dictionary<uint, List<uint>> RoleAugmentIdsByUniqueId { get; } = new();
+
+    /// <summary>最近一次 special_goods 购买绑定的核心角色 uniqueId。</summary>
+    public uint LastSpecialGoodsTargetUniqueId { get; set; }
     
     public uint ShopRefreshLeft { get; set; } = 2;
     public uint ShopRollCounter { get; set; }
     public List<GridFightShopGoodsInfo> ShopGoods { get; } = new();
     public List<uint> ShopRolePool { get; } = new();
+
+    /// <summary>最近一次成功购买的商店槽位索引，用于幂等重试。</summary>
+    public int LastBoughtShopIndex { get; set; } = -1;
+
+    /// <summary>最近一次成功购买生成的角色 uniqueId。</summary>
+    public uint LastBoughtUniqueId { get; set; }
 
     
     public List<uint> StageCandidates { get; } = new() { 35030205, 35030405, 35030208, 350202, 35030606 };
@@ -75,6 +99,12 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     public List<uint> CurrentPortalBuffOffer { get; private set; } = new();
     
     public List<uint> ActiveAugmentIds { get; } = new();
+
+    /// <summary>本局是否已触发三星昔涟出战专属免费商店。</summary>
+    public bool CyreneSpecialShopTriggered { get; set; }
+
+    /// <summary>已激活「头号玩家」GM 控制台的角色 uniqueId（15061/15062/15063）。</summary>
+    public HashSet<uint> HeadPlayerActivatedUniqueIds { get; } = new();
     
     public uint LastEncounterQuality { get; set; }
     public uint LastEncounterAppliedSection { get; set; }
@@ -104,7 +134,7 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     private static readonly uint[] FallbackPortalBuffPool =
     {
         101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115,
-        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 127, 129, 134, 135, 138,
+        116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 127, 129, 132, 134, 135, 138,
         147, 1001, 1002, 1003, 1004, 1005, 1007, 1008, 1010, 1014, 1016,
         1101, 1102, 1104, 1106, 1107, 1108, 1112, 1113, 1114, 1115, 1116, 1118
     };
@@ -136,11 +166,25 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         return CurrentPortalBuffOffer;
     }
 
+    /// <summary>
+    /// 获取当前 portal 三选一列表；优先沿用 pending 下发给客户端的选项，避免重掷导致校验失败。
+    /// </summary>
     public List<uint> EnsurePortalBuffOffer()
     {
+        if (CurrentPortalBuffOffer.Count == 0
+            && PendingAction?.PortalBuffAction?.GridFightPortalBuffList is { Count: > 0 } pendingOffer)
+        {
+            CurrentPortalBuffOffer = pendingOffer.ToList();
+        }
         if (CurrentPortalBuffOffer.Count == 0) RollPortalBuffs();
         return CurrentPortalBuffOffer;
     }
+
+    /// <summary>
+    /// 判断 portal buff 是否尚未完成选择（未激活 buff 且未同步初始备战角色）。
+    /// </summary>
+    public bool IsPortalBuffSelectionPending() =>
+        !InitialBenchRolesSynced && ActivePortalBuffIds.Count == 0;
 
     public void ClearPortalBuffOffer() => CurrentPortalBuffOffer = new List<uint>();
 
@@ -404,18 +448,300 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         PendingAction = null;
     }
 
-    public void ApplyPositionList(IEnumerable<GridFightPosInfo> posInfoList)
+    /// <summary>
+    /// 校验并应用走位（含换位）；出战席（pos 1-13）禁止同名角色并存。
+    /// </summary>
+    /// <returns>实际发生位置变化的角色列表，供 sync 使用。</returns>
+    public (Retcode retcode, List<GridFightPosInfo> affected) TryValidateAndApplyPositionList(
+        IEnumerable<GridFightPosInfo> posInfoList)
     {
         EnsureDefaultRoles();
-        foreach (var posInfo in posInfoList)
+        var updates = posInfoList.Where(p => p.Pos > 0).ToList();
+        if (updates.Count == 0)
+            return (Retcode.RetSucc, []);
+
+        var projected = new Dictionary<uint, uint>(UniqueIdByPos);
+        foreach (var posInfo in updates)
         {
-            if (posInfo.Pos == 0) continue;
-            foreach (var stale in UniqueIdByPos
-                         .Where(kv => kv.Key != posInfo.Pos && kv.Value == posInfo.UniqueId)
-                         .Select(kv => kv.Key).ToList())
-                UniqueIdByPos.Remove(stale);
-            UniqueIdByPos[posInfo.Pos] = posInfo.UniqueId;
+            if (posInfo.UniqueId != 0 && !RoleByUniqueId.ContainsKey(posInfo.UniqueId))
+                return (Retcode.RetGridFightRoleNotExist, []);
+
+            ApplyProjectedMove(projected, posInfo.Pos, posInfo.UniqueId);
         }
+
+        var battlefieldRoleIds = projected
+            .Where(kv => kv.Key is >= 1 and <= 13 && kv.Value != 0)
+            .Select(kv => GridFightRoleLookup.ToAvatarId(RoleByUniqueId.GetValueOrDefault(kv.Value)))
+            .Where(id => id != 0)
+            .ToList();
+        if (battlefieldRoleIds.Count != battlefieldRoleIds.Distinct().Count())
+            return (Retcode.RetGridFightSameRoleInBattle, []);
+
+        var affected = new List<GridFightPosInfo>();
+        foreach (var posInfo in updates)
+        {
+            if (posInfo.UniqueId == 0)
+            {
+                if (UniqueIdByPos.Remove(posInfo.Pos, out var removedUid) && removedUid != 0)
+                    affected.Add(new GridFightPosInfo { Pos = 0, UniqueId = removedUid });
+                continue;
+            }
+
+            ApplyActualMove(affected, posInfo.Pos, posInfo.UniqueId);
+        }
+
+        return (Retcode.RetSucc, affected);
+    }
+
+    /// <summary>
+    /// 在投影布局上模拟单次走位（含目标位互换）。
+    /// </summary>
+    private static void ApplyProjectedMove(Dictionary<uint, uint> layout, uint targetPos, uint movingUid)
+    {
+        if (movingUid == 0)
+        {
+            layout.Remove(targetPos);
+            return;
+        }
+
+        var sourcePos = layout.FirstOrDefault(kv => kv.Value == movingUid).Key;
+        var displacedUid = layout.GetValueOrDefault(targetPos);
+
+        if (sourcePos > 0 && sourcePos != targetPos)
+            layout.Remove(sourcePos);
+
+        if (displacedUid != 0 && displacedUid != movingUid)
+        {
+            if (sourcePos > 0)
+                layout[sourcePos] = displacedUid;
+            else
+                layout.Remove(targetPos);
+        }
+
+        layout[targetPos] = movingUid;
+    }
+
+    /// <summary>
+    /// 应用单次走位并记录所有受影响角色，便于客户端同步。
+    /// </summary>
+    private void ApplyActualMove(List<GridFightPosInfo> affected, uint targetPos, uint movingUid)
+    {
+        var sourcePos = UniqueIdByPos.FirstOrDefault(kv => kv.Value == movingUid).Key;
+        var displacedUid = UniqueIdByPos.GetValueOrDefault(targetPos);
+
+        if (sourcePos > 0 && sourcePos != targetPos)
+            UniqueIdByPos.Remove(sourcePos);
+
+        if (displacedUid != 0 && displacedUid != movingUid)
+        {
+            if (sourcePos > 0)
+            {
+                UniqueIdByPos[sourcePos] = displacedUid;
+                affected.Add(new GridFightPosInfo { Pos = sourcePos, UniqueId = displacedUid });
+            }
+            else if (TryAllocBenchPos(out var benchPos))
+            {
+                UniqueIdByPos[benchPos] = displacedUid;
+                affected.Add(new GridFightPosInfo { Pos = benchPos, UniqueId = displacedUid });
+            }
+        }
+
+        UniqueIdByPos[targetPos] = movingUid;
+        affected.Add(new GridFightPosInfo { Pos = targetPos, UniqueId = movingUid });
+    }
+
+    /// <summary>
+    /// 构建用于 sync 的角色快照。
+    /// </summary>
+    public GridGameRoleInfo BuildGridGameRoleInfo(uint uniqueId, uint pos = 0)
+    {
+        if (!RoleByUniqueId.TryGetValue(uniqueId, out var roleKey))
+            return new GridGameRoleInfo();
+
+        var syncRoleId = GridFightRoleLookup.ToSyncRoleId(roleKey);
+        if (pos == 0)
+            pos = UniqueIdByPos.FirstOrDefault(kv => kv.Value == uniqueId).Key;
+
+        var roleInfo = new GridGameRoleInfo
+        {
+            Id = syncRoleId,
+            Pos = pos,
+            UniqueId = uniqueId,
+            RoleStar = RoleStarByUniqueId.GetValueOrDefault(uniqueId, 1u)
+        };
+        if (GridFightRoleLookup.TryFind(roleKey, out var roleExcel)
+            && roleExcel.RoleSavedValueList.Count > 0)
+            roleInfo.GridFightValueInitComponent[roleExcel.RoleSavedValueList[0]] = 0;
+        return roleInfo;
+    }
+
+    /// <summary>
+    /// 解析角色当前站位；未找到时返回 0。
+    /// </summary>
+    public uint ResolveRolePos(uint uniqueId) =>
+        UniqueIdByPos.FirstOrDefault(kv => kv.Value == uniqueId).Key;
+
+    /// <summary>
+    /// 绑定 augment 至指定角色（出战席/备战席均可；不校验角色类型）。
+    /// </summary>
+    public void BindRoleAugment(uint uniqueId, uint augmentId)
+    {
+        if (!GameData.GridFightAugmentData.ContainsKey(augmentId))
+            return;
+
+        if (!RoleAugmentIdsByUniqueId.TryGetValue(uniqueId, out var augments))
+        {
+            augments = [];
+            RoleAugmentIdsByUniqueId[uniqueId] = augments;
+        }
+
+        if (!augments.Contains(augmentId))
+            augments.Add(augmentId);
+    }
+
+    /// <summary>
+    /// 构建备战段用的角色 augment 绑定条目（pos + uniqueId + augmentId）。
+    /// </summary>
+    public CKCKIDHMMEG BuildPrepRoleAugmentBinding(uint uniqueId, uint augmentId, uint pos = 0)
+    {
+        if (pos == 0)
+            pos = ResolveRolePos(uniqueId);
+
+        return new CKCKIDHMMEG
+        {
+            Pos = pos,
+            UniqueId = uniqueId,
+            JCMFPHMFAON = augmentId
+        };
+    }
+
+    /// <summary>
+    /// 构建战斗段用的角色 augment 绑定条目（pos + uniqueId + augmentId）。
+    /// </summary>
+    public CCGEOHGFAFD BuildBattleRoleAugmentBinding(uint uniqueId, uint augmentId, uint pos = 0)
+    {
+        if (pos == 0)
+            pos = ResolveRolePos(uniqueId);
+
+        return new CCGEOHGFAFD
+        {
+            Pos = pos,
+            UniqueId = uniqueId,
+            JCMFPHMFAON = augmentId
+        };
+    }
+
+    /// <summary>
+    /// 获取角色绑定的首个 augment ID；无绑定时返回 0。
+    /// </summary>
+    public uint GetPrimaryRoleAugmentId(uint uniqueId) =>
+        RoleAugmentIdsByUniqueId.TryGetValue(uniqueId, out var augments) && augments.Count > 0
+            ? augments[0]
+            : 0u;
+
+    /// <summary>
+    /// 填充队伍段 MMAJCLACOBN（角色 augment 绑定全量 sync）。
+    /// </summary>
+    public void PopulatePrepRoleAugmentBindings(GridFightGameTeamInfo team)
+    {
+        foreach (var (pos, uniqueId) in UniqueIdByPos.OrderBy(kv => kv.Key))
+        {
+            if (uniqueId == 0 || !RoleAugmentIdsByUniqueId.TryGetValue(uniqueId, out var augments))
+                continue;
+
+            foreach (var augmentId in augments)
+                team.MMAJCLACOBN.Add(BuildPrepRoleAugmentBinding(uniqueId, augmentId, pos));
+        }
+    }
+
+    /// <summary>
+    /// 向 sync 段追加 BAODHPCOJLH（单角色 augment 绑定增量同步）。
+    /// </summary>
+    public static void AppendRoleAugmentBindingSync(
+        GridFightSyncResultData sync,
+        GridFightInstance inst,
+        uint uniqueId,
+        uint augmentId)
+    {
+        sync.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            BAODHPCOJLH = inst.BuildPrepRoleAugmentBinding(uniqueId, augmentId)
+        });
+    }
+
+    /// <summary>
+    /// 枚举当前棋盘与备战席上的全部有效角色（pos 1-22，不含临时溢出位）。
+    /// </summary>
+    public IEnumerable<(uint UniqueId, uint Pos)> EnumerateBoardRoles()
+    {
+        foreach (var (pos, uniqueId) in UniqueIdByPos.OrderBy(kv => kv.Key))
+        {
+            if (pos is < 1 or > BenchPosMax || uniqueId == 0) continue;
+            if (!RoleByUniqueId.ContainsKey(uniqueId)) continue;
+            yield return (uniqueId, pos);
+        }
+    }
+
+    /// <summary>
+    /// 扫描全场角色并执行所有可触发的三连升星；每次只合成一组，直到无可合成组合。
+    /// </summary>
+    public List<RoleMergeResult> TryAutoMergeAllRoles()
+    {
+        var results = new List<RoleMergeResult>();
+        while (true)
+        {
+            var mergedAny = false;
+            var roleIds = RoleByUniqueId.Values
+                .Select(GridFightRoleLookup.ToRoleId)
+                .Where(id => id != 0)
+                .Distinct()
+                .ToList();
+
+            foreach (var roleId in roleIds)
+            {
+                while (TryFindMergeableStarter(roleId, out var starter))
+                {
+                    var merge = TryAutoMergeRole(roleId, starter);
+                    if (!merge.Merged) break;
+                    results.Add(merge);
+                    mergedAny = true;
+                }
+            }
+
+            if (!mergedAny) break;
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// 查找指定角色是否存在可三连合成的星级组，并返回其中一张参与卡的 uniqueId。
+    /// </summary>
+    private bool TryFindMergeableStarter(uint roleId, out uint starterUid)
+    {
+        starterUid = 0;
+        roleId = GridFightRoleLookup.ToRoleId(roleId);
+        if (roleId == 0) return false;
+
+        var mergeableGroup = RoleByUniqueId
+            .Where(kv => GridFightRoleLookup.ToRoleId(kv.Value) == roleId)
+            .GroupBy(kv => RoleStarByUniqueId.GetValueOrDefault(kv.Key, 1u))
+            .FirstOrDefault(g => g.Count() >= 3);
+        if (mergeableGroup == null) return false;
+
+        starterUid = mergeableGroup.First().Key;
+        return starterUid != 0;
+    }
+
+    /// <summary>
+    /// 对指定角色尝试三连升星（备战席与出战席均参与合成）。
+    /// </summary>
+    public RoleMergeResult TryAutoMergeRolesForRole(uint roleId)
+    {
+        var syncRoleId = GridFightRoleLookup.ToRoleId(roleId);
+        var starter = RoleByUniqueId
+            .FirstOrDefault(kv => GridFightRoleLookup.ToRoleId(kv.Value) == syncRoleId).Key;
+        return starter == 0 ? new RoleMergeResult() : TryAutoMergeRole(syncRoleId, starter);
     }
 
     public List<(uint RoleId, uint Pos)> ResolveForegroundRoles()
@@ -453,8 +779,7 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         return ResolveBackgroundRoles().Select(t => RoleIdToAvatarId(t.RoleId)).Where(id => id != 0).ToList();
     }
 
-    private static int RoleIdToAvatarId(uint roleId) =>
-        GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var e) ? (int)e.AvatarID : (int)roleId;
+    private static int RoleIdToAvatarId(uint roleKey) => (int)GridFightRoleLookup.ToAvatarId(roleKey);
 
     public List<IENNMHMOONM> CheckTrait()
     {
@@ -465,8 +790,9 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         foreach (var kv in UniqueIdByPos.Where(kv => kv.Key is > 0 and <= 13))
         {
             var uniqueId = kv.Value;
-            if (uniqueId == 0 || !RoleByUniqueId.TryGetValue(uniqueId, out var roleId)) continue;
-            if (!GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var role)) continue;
+            if (uniqueId == 0 || !RoleByUniqueId.TryGetValue(uniqueId, out var roleKey)) continue;
+            var role = GridFightRoleLookup.Find(roleKey);
+            if (role == null) continue;
             var roleTraits = new HashSet<uint>(role.TraitList);
             if (EquipUniqueIdsByRoleUniqueId.TryGetValue(uniqueId, out var dressed))
             {
@@ -569,6 +895,8 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     {
         ShopGoods.Clear();
         ShopRollCounter++;
+        LastBoughtShopIndex = -1;
+        LastBoughtUniqueId = 0;
 
         var rng = Random.Shared;
         var rarityWeights = GetShopRarityWeights();
@@ -593,15 +921,80 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         }
     }
 
-    private List<uint> GetShopRarityWeights()
+    private List<uint> GetShopRarityWeights() => GetShopRarityWeightsForLevel(PlayerLevel);
+
+    /// <summary>
+    /// 读取指定玩家等级对应的商店费用权重（与 RollShopRarity 使用同一配置）。
+    /// </summary>
+    public static List<uint> GetShopRarityWeightsForLevel(uint playerLevel)
     {
-        if (GameData.GridFightPlayerLevelData.TryGetValue(PlayerLevel, out var conf)
+        if (GameData.GridFightPlayerLevelData.TryGetValue(playerLevel, out var conf)
             && conf.RarityWeights.Count >= 5)
             return conf.RarityWeights;
         return [100, 0, 0, 0, 0];
     }
 
+    /// <summary>
+    /// 构建商店 UI 费用概率展示数据（LDEDGOOKHFL / FLICPMGFKOK）。
+    /// </summary>
+    public FJPONJFLOOH BuildShopRarityDisplayInfo() =>
+        BuildShopRarityDisplayInfoForLevel(PlayerLevel);
+
+    /// <summary>
+    /// 按玩家等级构建商店各费用档位出现概率，供 sync 与 ToProto 使用。
+    /// </summary>
+    public static FJPONJFLOOH BuildShopRarityDisplayInfoForLevel(uint playerLevel)
+    {
+        var weights = GetShopRarityWeightsForLevel(playerLevel);
+        var info = new FJPONJFLOOH();
+        for (var i = 0; i < 5; i++)
+        {
+            info.EDJPMNLLGGB.Add(new MJJEHCBNOKI
+            {
+                MMKNFIFOPPA = (uint)(i + 1),
+                FLICPMGFKOK = i < weights.Count ? weights[i] : 0u
+            });
+        }
+        return info;
+    }
+
     private Dictionary<uint, List<uint>> BuildShopRolePoolByRarity()
+    {
+        var excluded = GetShopExcludedRoleIds();
+        var dict = BuildShopRolePoolByRarityCore(excluded);
+        if (dict.Values.All(static lists => lists.Count == 0) && excluded.Count > 0)
+            dict = BuildShopRolePoolByRarityCore(null);
+        return dict;
+    }
+
+    /// <summary>
+    /// 收集出战席（pos 1-13）与备战席（pos 14+）上 3 星及以上角色的内部 roleId，供商店刷新时从候选池排除。
+    /// </summary>
+    private HashSet<uint> GetShopExcludedRoleIds()
+    {
+        var excluded = new HashSet<uint>();
+        foreach (var (pos, uniqueId) in UniqueIdByPos)
+        {
+            if (uniqueId == 0) continue;
+            if (!IsBattlefieldOrBenchPos(pos)) continue;
+            if (RoleStarByUniqueId.GetValueOrDefault(uniqueId, 1u) < 3) continue;
+            if (!RoleByUniqueId.TryGetValue(uniqueId, out var roleKey)) continue;
+            excluded.Add(GridFightRoleLookup.ToRoleId(roleKey));
+        }
+        return excluded;
+    }
+
+    /// <summary>
+    /// 判断 pos 是否属于出战席或备战席（不含临时溢出落点）。
+    /// </summary>
+    private static bool IsBattlefieldOrBenchPos(uint pos) =>
+        pos is >= BattlefieldPosMin and <= BattlefieldPosMax
+        || pos is >= BenchPosMin and <= BenchPosMax;
+
+    /// <summary>
+    /// 按稀有度构建商店角色候选池；excludedRoleIds 非空时排除对应角色。
+    /// </summary>
+    private Dictionary<uint, List<uint>> BuildShopRolePoolByRarityCore(IReadOnlySet<uint>? excludedRoleIds)
     {
         var dict = new Dictionary<uint, List<uint>>();
         foreach (var role in GameData.GridFightRoleBasicInfoData.Values)
@@ -609,6 +1002,7 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
             if (!role.IsInPool) continue;
             if (role.SeasonID != 0 && role.SeasonID != Season) continue;
             if (role.AvatarID < 1000 || role.AvatarID >= 2000) continue;
+            if (excludedRoleIds != null && excludedRoleIds.Contains(role.ID)) continue;
             if (!dict.TryGetValue(role.Rarity, out var list))
                 dict[role.Rarity] = list = [];
             list.Add(role.ID);
@@ -650,78 +1044,201 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         };
     }
 
-    public (bool ok, uint addedUniqueId, uint roleId, uint pos) TryBuyGoods(int shopIndex)
+    public (bool ok, uint addedUniqueId, uint roleId, uint pos, List<GridFightPosInfo> benchMoved, bool duplicateRetry, uint purchasedAugmentId, Retcode retcode) TryBuyGoods(int shopIndex)
     {
-        if (shopIndex < 0 || shopIndex >= ShopGoods.Count) return (false, 0, 0, 0);
+        if (shopIndex < 0 || shopIndex >= ShopGoods.Count)
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightParamNotMatch);
         var goods = ShopGoods[shopIndex];
-        if (goods.RoleGoodsInfo == null || goods.IsSoldOut) return (false, 0, 0, 0);
-        var price = goods.ShopGoodsPrice;
-        if (Gold < price) Gold = price; 
+        if (goods.SpecialGoodsInfo != null)
+            return TryBuySpecialGoods(shopIndex, goods);
+
+        if (goods.RoleGoodsInfo == null)
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightParamNotMatch);
+        if (goods.IsSoldOut)
+        {
+            if (LastBoughtShopIndex == shopIndex)
+            {
+                if (LastBoughtUniqueId != 0 && RoleByUniqueId.ContainsKey(LastBoughtUniqueId))
+                {
+                    var uid = LastBoughtUniqueId;
+                    var existingPos = UniqueIdByPos.FirstOrDefault(kv => kv.Value == uid).Key;
+                    var existingRoleId = GridFightRoleLookup.ToSyncRoleId(RoleByUniqueId[uid]);
+                    return (true, uid, existingRoleId, existingPos, [], true, 0, Retcode.RetSucc);
+                }
+
+                var soldRoleId = goods.RoleGoodsInfo.RoleId;
+                var keptUid = RoleByUniqueId
+                    .FirstOrDefault(kv => GridFightRoleLookup.ToRoleId(kv.Value) == soldRoleId).Key;
+                if (keptUid != 0)
+                {
+                    var keptPos = UniqueIdByPos.FirstOrDefault(kv => kv.Value == keptUid).Key;
+                    return (true, keptUid, soldRoleId, keptPos, [], true, 0, Retcode.RetSucc);
+                }
+
+                return (true, 0, 0, 0, [], true, 0, Retcode.RetSucc);
+            }
+
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightGoodsSold);
+        }
+
+        var star = goods.RoleGoodsInfo.RoleStar > 0 ? goods.RoleGoodsInfo.RoleStar : 1u;
+        var roleId = goods.RoleGoodsInfo.RoleId;
+        var price = GetShopGoodsPrice(
+            GridFightRoleLookup.TryFind(roleId, out var roleExcel) ? roleExcel.Rarity : 1u,
+            star);
+        if (Gold < price)
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightCoinNotEnough);
+
+        if (!TryAcquirePurchasePos(roleId, star, out var pos))
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightNoEmptyPos);
+
         Gold -= price;
         goods.IsSoldOut = true;
-        var roleId = goods.RoleGoodsInfo.RoleId;
         var uniqueId = AllocRoleUniqueId();
         RoleByUniqueId[uniqueId] = roleId;
-        RoleStarByUniqueId[uniqueId] = 1;
-        
-        uint pos = 0;
-        foreach (var candidate in new uint[] { 14, 15, 16, 17, 18, 6, 7, 8, 9, 10, 11, 12, 13 })
-        {
-            if (!UniqueIdByPos.ContainsKey(candidate))
-            {
-                pos = candidate;
-                break;
-            }
-        }
-        if (pos > 0) UniqueIdByPos[pos] = uniqueId;
-        return (true, uniqueId, roleId, pos);
+        RoleStarByUniqueId[uniqueId] = star;
+        UniqueIdByPos[pos] = uniqueId;
+        LastBoughtShopIndex = shopIndex;
+        LastBoughtUniqueId = uniqueId;
+        return (true, uniqueId, roleId, pos, [], false, 0, Retcode.RetSucc);
     }
 
+    /// <summary>
+    /// 购买昔涟专属诗篇等特殊商品：仅绑定至出战席三星昔涟。
+    /// </summary>
+    private (bool ok, uint addedUniqueId, uint roleId, uint pos, List<GridFightPosInfo> benchMoved, bool duplicateRetry, uint purchasedAugmentId, Retcode retcode) TryBuySpecialGoods(
+        int shopIndex,
+        GridFightShopGoodsInfo goods)
+    {
+        var augmentId = goods.SpecialGoodsInfo!.SpecialGoodsId;
+        if (augmentId == 0)
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightParamNotMatch);
+        if (!GameData.GridFightAugmentData.ContainsKey(augmentId))
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightParamNotMatch);
+
+        if (!GridFightCyreneSpecialShopService.TryGetThreeStarCyreneBattlefieldRole(this, out var targetUid, out _))
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightParamNotMatch);
+
+        if (goods.IsSoldOut)
+        {
+            if (LastBoughtShopIndex == shopIndex
+                && RoleAugmentIdsByUniqueId.TryGetValue(targetUid, out var owned)
+                && owned.Contains(augmentId))
+            {
+                LastSpecialGoodsTargetUniqueId = targetUid;
+                return (true, 0, 0, 0, [], true, augmentId, Retcode.RetSucc);
+            }
+
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightGoodsSold);
+        }
+
+        if (RoleAugmentIdsByUniqueId.TryGetValue(targetUid, out var existing) && existing.Contains(augmentId))
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightParamNotMatch);
+
+        var price = goods.ShopGoodsPrice;
+        if (Gold < price)
+            return (false, 0, 0, 0, [], false, 0, Retcode.RetGridFightCoinNotEnough);
+
+        Gold -= price;
+        goods.IsSoldOut = true;
+        LastBoughtShopIndex = shopIndex;
+        LastBoughtUniqueId = 0;
+        LastSpecialGoodsTargetUniqueId = targetUid;
+
+        BindRoleAugment(targetUid, augmentId);
+
+        return (true, 0, 0, 0, [], false, augmentId, Retcode.RetSucc);
+    }
+
+    /// <summary>
+    /// 对指定角色尝试一次三连升星（备战席与出战席均参与合成）。
+    /// </summary>
     public RoleMergeResult TryAutoMergeRole(uint roleId, uint roleUniqueId)
     {
         var result = new RoleMergeResult();
+        roleId = GridFightRoleLookup.ToRoleId(roleId);
         if (roleId == 0 || roleUniqueId == 0) return result;
+        if (!TryFindMergeableGroup(roleId, roleUniqueId, out var starTier, out var sameTier))
+            return result;
 
-        var keepUniqueId = roleUniqueId;
-        var currentStar = RoleStarByUniqueId.GetValueOrDefault(keepUniqueId, 1u);
-        while (true)
+        var nextStar = starTier + 1;
+        if (!CanRoleUpgradeToStar(roleId, nextStar))
+            return result;
+
+        var keepUniqueId = sameTier.Contains(roleUniqueId) ? roleUniqueId : sameTier[0];
+        var consume = sameTier.Where(x => x != keepUniqueId).Take(2).ToList();
+        if (consume.Count < 2) return result;
+
+        result.RoleId = roleId;
+        foreach (var uid in sameTier)
         {
-            var nextStar = currentStar + 1;
-            if (!GameData.GridFightRoleStarData.ContainsKey(roleId << 4 | nextStar))
-                break;
-
-            var sameTier = RoleByUniqueId
-                .Where(kv => kv.Value == roleId && RoleStarByUniqueId.GetValueOrDefault(kv.Key, 1u) == currentStar)
-                .Select(kv => kv.Key)
-                .Distinct()
-                .ToList();
-            if (sameTier.Count < 3) break;
-
-            if (!sameTier.Contains(keepUniqueId))
-                keepUniqueId = sameTier[0];
-
-            var consume = sameTier.Where(x => x != keepUniqueId).Take(2).ToList();
-            if (consume.Count < 2) break;
-
-            foreach (var uid in consume)
-            {
-                RoleByUniqueId.Remove(uid);
-                RoleStarByUniqueId.Remove(uid);
-                foreach (var pos in UniqueIdByPos.Where(kv => kv.Value == uid).Select(kv => kv.Key).ToList())
-                    UniqueIdByPos.Remove(pos);
-                result.RemovedUniqueIds.Add(uid);
-            }
-
-            currentStar = nextStar;
-            RoleStarByUniqueId[keepUniqueId] = currentStar;
+            result.PreMergeRoleSnapshots[uid] = BuildGridGameRoleInfo(uid);
+            var participantPos = UniqueIdByPos.FirstOrDefault(kv => kv.Value == uid).Key;
+            if (participantPos > 0)
+                result.ParticipantPosByUniqueId[uid] = participantPos;
         }
 
-        if (result.RemovedUniqueIds.Count > 0)
+        foreach (var uid in consume)
         {
-            result.KeptUniqueId = keepUniqueId;
-            result.NewStar = RoleStarByUniqueId.GetValueOrDefault(keepUniqueId, 1u);
+            RoleByUniqueId.Remove(uid);
+            RoleStarByUniqueId.Remove(uid);
+            foreach (var pos in UniqueIdByPos.Where(kv => kv.Value == uid).Select(kv => kv.Key).ToList())
+                UniqueIdByPos.Remove(pos);
+            result.RemovedUniqueIds.Add(uid);
         }
+
+        RoleStarByUniqueId[keepUniqueId] = nextStar;
+        result.KeptUniqueId = keepUniqueId;
+        result.NewStar = nextStar;
+        result.FinalKeeperRoleInfo = BuildGridGameRoleInfo(keepUniqueId);
         return result;
+    }
+
+    /// <summary>
+    /// 查找指定角色当前可合成的星级组；优先使用 hintUid 所在星级。
+    /// </summary>
+    private bool TryFindMergeableGroup(uint roleId, uint hintUid, out uint starTier, out List<uint> sameTier)
+    {
+        starTier = 0;
+        sameTier = [];
+
+        var groups = RoleByUniqueId
+            .Where(kv => GridFightRoleLookup.ToRoleId(kv.Value) == roleId)
+            .GroupBy(kv => RoleStarByUniqueId.GetValueOrDefault(kv.Key, 1u))
+            .Where(g => g.Count() >= 3)
+            .OrderBy(g => g.Key)
+            .ToList();
+        if (groups.Count == 0) return false;
+
+        if (hintUid != 0
+            && RoleByUniqueId.ContainsKey(hintUid)
+            && GridFightRoleLookup.ToRoleId(RoleByUniqueId[hintUid]) == roleId)
+        {
+            var hintStar = RoleStarByUniqueId.GetValueOrDefault(hintUid, 1u);
+            var hintGroup = groups.FirstOrDefault(g => g.Key == hintStar);
+            if (hintGroup != null)
+            {
+                starTier = hintStar;
+                sameTier = hintGroup.Select(kv => kv.Key).Distinct().ToList();
+                return sameTier.Count >= 3;
+            }
+        }
+
+        var first = groups[0];
+        starTier = first.Key;
+        sameTier = first.Select(kv => kv.Key).Distinct().ToList();
+        return sameTier.Count >= 3;
+    }
+
+    /// <summary>
+    /// 判断角色能否升到指定星级；配置缺失时允许升至 3 星以匹配客户端默认规则。
+    /// </summary>
+    private static bool CanRoleUpgradeToStar(uint roleKey, uint nextStar)
+    {
+        var internalId = GridFightRoleLookup.ToRoleId(roleKey);
+        if (GameData.GridFightRoleStarData.ContainsKey(internalId << 4 | nextStar))
+            return true;
+        return nextStar <= 3;
     }
 
     public (bool ok, uint refund) TryRecycleRole(uint uniqueId)
@@ -737,9 +1254,9 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         return (true, refund);
     }
 
-    private static uint GetRoleSellPrice(uint roleId, uint roleStar)
+    private static uint GetRoleSellPrice(uint roleKey, uint roleStar)
     {
-        if (!GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var role))
+        if (!GridFightRoleLookup.TryFind(roleKey, out var role))
             return 1;
         if (!GameData.GridFightShopPriceData.TryGetValue(role.Rarity, out var priceConf))
             return 1;
@@ -776,11 +1293,184 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         return 4;
     }
 
-    public uint GetCurrentMaxBattleRoleNum()
+    /// <summary>备战席固定 9 格（pos 14-22）。</summary>
+    public const uint BenchSlotCount = 9;
+    public const uint BenchPosMin = 14;
+    public const uint BenchPosMax = BenchPosMin + BenchSlotCount - 1;
+    public const uint BattlefieldPosMin = 1;
+    public const uint BattlefieldPosMax = 13;
+
+    /// <summary>出战席前台固定格数（pos 1-4）。</summary>
+    public const uint BattlefieldForegroundMax = 4;
+
+    /// <summary>
+    /// 统计指定角色在某星级的现有数量。
+    /// </summary>
+    public uint CountRolesAtStar(uint roleKey, uint star)
     {
-        if (GameData.GridFightPlayerLevelData.TryGetValue(PlayerLevel, out var conf))
-            return Math.Clamp(conf.AvatarMaxNumber, 0u, 13u);
-        return 4;
+        var roleId = GridFightRoleLookup.ToRoleId(roleKey);
+        if (roleId == 0) return 0;
+        return (uint)RoleByUniqueId.Count(kv =>
+            GridFightRoleLookup.ToRoleId(kv.Value) == roleId
+            && RoleStarByUniqueId.GetValueOrDefault(kv.Key, 1u) == star);
+    }
+
+    /// <summary>
+    /// 购买一张同角色同星级卡是否会触发三连升星（已有至少 2 张）。
+    /// </summary>
+    public bool WouldPurchaseTriggerMerge(uint roleKey, uint star) => CountRolesAtStar(roleKey, star) >= 2;
+
+    /// <summary>
+    /// 分配购买落点；备战席满员时若购买可触发升星则允许临时溢出落点。
+    /// </summary>
+    public bool TryAcquirePurchasePos(uint roleKey, uint star, out uint pos)
+    {
+        if (TryAllocBenchPos(out pos))
+            return true;
+        if (!WouldPurchaseTriggerMerge(roleKey, star))
+            return false;
+
+        pos = BenchPosMax + 1;
+        return true;
+    }
+
+    /// <summary>
+    /// 升星后回收临时溢出落点（pos &gt; 22），不压缩已有备战席布局。
+    /// </summary>
+    public List<GridFightPosInfo> FinalizeBenchAfterMerge()
+    {
+        var moved = new List<GridFightPosInfo>();
+        var overflowEntries = UniqueIdByPos
+            .Where(kv => kv.Key > BenchPosMax && kv.Value != 0)
+            .ToList();
+        foreach (var (overflowPos, uid) in overflowEntries)
+        {
+            UniqueIdByPos.Remove(overflowPos);
+            if (!RoleByUniqueId.ContainsKey(uid)) continue;
+            if (!TryAllocBenchPos(out var benchPos)) continue;
+            UniqueIdByPos[benchPos] = uid;
+            moved.Add(new GridFightPosInfo { Pos = benchPos, UniqueId = uid });
+        }
+
+        return moved;
+    }
+
+    /// <summary>
+    /// 将备战席角色压缩到连续低位 pos，返回位置发生变化的角色。
+    /// </summary>
+    public List<GridFightPosInfo> CompactBenchSlots()
+    {
+        var moved = new List<GridFightPosInfo>();
+        var benchRoles = UniqueIdByPos
+            .Where(kv => kv.Key is >= BenchPosMin and <= BenchPosMax && kv.Value != 0)
+            .OrderBy(kv => kv.Key)
+            .ToList();
+
+        foreach (var (pos, _) in benchRoles)
+            UniqueIdByPos.Remove(pos);
+
+        for (var i = 0; i < benchRoles.Count; i++)
+        {
+            var newPos = BenchPosMin + (uint)i;
+            var uid = benchRoles[i].Value;
+            var oldPos = benchRoles[i].Key;
+            UniqueIdByPos[newPos] = uid;
+            if (newPos != oldPos)
+                moved.Add(new GridFightPosInfo { Pos = newPos, UniqueId = uid });
+        }
+
+        return moved;
+    }
+
+    /// <summary>出战总人数硬上限（含特殊效果加成后）。</summary>
+    public const uint MaxBattleDeployTotal = 13;
+
+    /// <summary>财富宝钻装备 ID；持有则上阵人数 +1。</summary>
+    public const uint WealthGemEquipmentId = 350701;
+
+    /// <summary>是否已向客户端同步过开局备战席角色。</summary>
+    public bool InitialBenchRolesSynced { get; set; }
+
+    /// <summary>
+    /// 返回备战席槽位数（客户端 grid_fight_max_avatar_count），固定为 9。
+    /// </summary>
+    public uint GetBenchSlotCount() => BenchSlotCount;
+
+    /// <summary>
+    /// 是否持有财富宝钻；物品栏与角色穿戴均计入（装备实例统一保存在 Equipments 中）。
+    /// </summary>
+    public bool HasWealthGem() =>
+        Equipments.Any(e => e.GridFightEquipmentId == WealthGemEquipmentId);
+
+    /// <summary>
+    /// 返回由装备/策略等提供的出战总人数额外上限（如财富宝钻 +1）。
+    /// </summary>
+    public uint GetDeployCapBonus() => HasWealthGem() ? 1u : 0u;
+
+    /// <summary>
+    /// 构建上阵总人数上限 sync（MaxBattleRoleNum，无条件 13）。
+    /// </summary>
+    public GridFightSyncData BuildMaxBattleRoleNumSyncData() =>
+        new() { MaxBattleRoleNum = GetCurrentMaxBattleRoleNum() };
+
+    /// <summary>
+    /// 构建后台区域物理格数 sync（GridFightOffFieldMaxCount = 总人数 - 前台 4 格）。
+    /// </summary>
+    public GridFightSyncData BuildOffFieldMaxCountSyncData() =>
+        new() { GridFightOffFieldMaxCount = GetCurrentOffFieldMaxCount() };
+
+    /// <summary>
+    /// 返回后台出战席物理格数；与 MaxBattleRoleNum 配套下发以扩展客户端棋盘。
+    /// </summary>
+    public uint GetCurrentOffFieldMaxCount() =>
+        GetCurrentMaxBattleRoleNum() > BattlefieldForegroundMax
+            ? GetCurrentMaxBattleRoleNum() - BattlefieldForegroundMax
+            : 0;
+
+    /// <summary>
+    /// 出战席布局相关 sync：总人数上限 + 后台物理格数。
+    /// </summary>
+    public IEnumerable<GridFightSyncData> BuildBattlefieldLayoutSyncData()
+    {
+        yield return BuildMaxBattleRoleNumSyncData();
+        yield return BuildOffFieldMaxCountSyncData();
+    }
+
+    /// <summary>
+    /// 向 sync 段追加出战席布局字段（MaxBattleRoleNum + GridFightOffFieldMaxCount）。
+    /// </summary>
+    public static void AppendBattlefieldLayoutSync(GridFightSyncResultData sync, GridFightInstance inst)
+    {
+        foreach (var entry in inst.BuildBattlefieldLayoutSyncData())
+            sync.UpdateDynamicList.Add(entry);
+    }
+
+    /// <summary>
+    /// 返回当前允许的上阵总人数（MaxBattleRoleNum 动态同步用）；无条件开放出战席 1-13。
+    /// </summary>
+    public uint GetCurrentMaxBattleRoleNum() => MaxBattleDeployTotal;
+
+    /// <summary>
+    /// Counts roles currently placed on the battlefield (pos 1-13).
+    /// </summary>
+    public uint GetDeployedBattleRoleCount() =>
+        (uint)UniqueIdByPos.Count(kv => kv.Key is >= 1 and <= 13 && kv.Value != 0);
+
+    /// <summary>
+    /// Tries to allocate the next free bench slot (pos 14+).
+    /// </summary>
+    public bool TryAllocBenchPos(out uint pos)
+    {
+        pos = 0;
+        for (uint i = 0; i < GetBenchSlotCount(); i++)
+        {
+            var candidate = BenchPosMin + i;
+            if (UniqueIdByPos.ContainsKey(candidate)) continue;
+            pos = candidate;
+            return true;
+        }
+
+        return false;
     }
 
     private void AddPlayerExp(uint value)
@@ -935,17 +1625,12 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     private void ApplyRoleGrant(OrbUseResult r, uint roleId)
     {
         if (!GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var roleExcel)) return;
-        uint pos = 0;
-        foreach (var candidate in new uint[] { 14, 15, 16, 17, 18, 19, 6, 7, 8, 9, 10, 11, 12, 13 })
-        {
-            if (!UniqueIdByPos.ContainsKey(candidate)) { pos = candidate; break; }
-        }
-        if (pos == 0) return;
+        if (!TryAllocBenchPos(out var pos)) return;
         var uid = AllocRoleUniqueId();
-        RoleByUniqueId[uid] = roleExcel.AvatarID;
+        RoleByUniqueId[uid] = roleId;
         RoleStarByUniqueId[uid] = 1;
         UniqueIdByPos[pos] = uid;
-        r.AddRoleId = roleExcel.AvatarID;
+        r.AddRoleId = roleId;
         r.AddRoleUniqueId = uid;
         r.AddRolePos = pos;
         if (roleExcel.RoleSavedValueList.Count > 0)
@@ -1040,17 +1725,26 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
     
     
     
+    /// <summary>
+    /// Resolves the elite group id used by battle monsters for the current section.
+    /// </summary>
     public uint ResolveEliteGroupForCurrentSection()
     {
         var route = Battle.GridFightLevelResolver.ResolveRoute(this);
-        if (route == null) return 1816;
-        if (route.NodeType == Enums.GridFight.GridFightNodeTypeEnum.Monster)
+        if (route?.NodeType == Enums.GridFight.GridFightNodeTypeEnum.Monster)
             return ResolveRewardEliteGroup(CurrentChapterId, SectionId);
-        if (route.NodeType == Enums.GridFight.GridFightNodeTypeEnum.Supply)
+        if (route?.NodeType == Enums.GridFight.GridFightNodeTypeEnum.Supply)
             return 0;
-        
-        var n = CountCombatNodesUpToCurrent();
-        return 1800u + Math.Max(1u, n);
+
+        return ResolveCombatEliteGroup();
+    }
+
+    /// <summary>
+    /// Returns the combat-progression elite group id shown in level/shop sync payloads.
+    /// </summary>
+    public uint ResolveCombatEliteGroup()
+    {
+        return 1800u + Math.Max(1u, CountCombatNodesUpToCurrent());
     }
 
     private static uint ResolveRewardEliteGroup(uint chapter, uint section)
@@ -1063,16 +1757,78 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
 
     private uint CountCombatNodesUpToCurrent()
     {
-        if (!GameData.GridFightStageRouteData.TryGetValue(RouteId, out var bucket)) return 1;
+        var route = Battle.GridFightLevelResolver.ResolveRoute(this);
+        if (route == null)
+            return 1;
+
+        if (!GameData.GridFightStageRouteData.TryGetValue(route.ID, out var bucket))
+            return 1;
+
         uint count = 0;
         foreach (var r in bucket.Values.OrderBy(r => r.ChapterID).ThenBy(r => r.SectionID))
         {
             if (r.NodeType == Enums.GridFight.GridFightNodeTypeEnum.Supply) continue;
-            if (r.NodeType == Enums.GridFight.GridFightNodeTypeEnum.Monster) continue; 
+            if (r.NodeType == Enums.GridFight.GridFightNodeTypeEnum.Monster) continue;
             count++;
-            if (r.ChapterID == CurrentChapterId && r.SectionID == SectionId) return count;
+            if (r.ChapterID == CurrentChapterId && r.SectionID == SectionId)
+                return count;
         }
-        return count;
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Aligns RouteId with the resolved stage-route table for the current chapter/section.
+    /// </summary>
+    public void EnsureRouteBinding()
+    {
+        var route = Battle.GridFightLevelResolver.ResolveRoute(this);
+        if (route != null)
+            RouteId = route.ID;
+    }
+
+    /// <summary>
+    /// Builds the route layer payload used by the client node map and battle preview.
+    /// </summary>
+    public GridFightLayerInfo BuildCurrentLayerInfo()
+    {
+        EnsureRouteBinding();
+
+        var routeInfo = new GridFightRouteInfo
+        {
+            FightCampId = 20,
+            EliteBranchId = CurrentBranchId > 0 ? CurrentBranchId : 1u
+        };
+
+        if (BattleComponent.StageId > 0 && BattleComponent.MonsterIds.Count > 0)
+        {
+            AppendRouteEncounter(routeInfo, BattleComponent.StageId, BattleComponent.MonsterIds);
+        }
+        else if (GridFightLevelResolver.IsCombatNode(this))
+        {
+            var encounter = GridFightLevelResolver.Resolve(this);
+            AppendRouteEncounter(routeInfo, encounter.StageId,
+                encounter.Monsters.Select(m => (m.MonsterId, m.RoleStar)));
+        }
+
+        return new GridFightLayerInfo { RouteInfo = routeInfo };
+    }
+
+    private static void AppendRouteEncounter(GridFightRouteInfo routeInfo, uint stageId,
+        IEnumerable<uint> monsterIds)
+    {
+        AppendRouteEncounter(routeInfo, stageId, monsterIds.Select(id => (id, 1u)));
+    }
+
+    private static void AppendRouteEncounter(GridFightRouteInfo routeInfo, uint stageId,
+        IEnumerable<(uint MonsterId, uint RoleStar)> monsterIds)
+    {
+        var encounterInfo = new GridFightEncounterInfo { LFKBMDHKPFI = stageId };
+        var wave = new GridEncounterMonsterWave { IGMMPDDCJIN = 1 };
+        foreach (var (monsterId, roleStar) in monsterIds)
+            wave.PPOEDDFFEKK.Add(new PJLBDMPEKFP { MonsterId = monsterId, RoleStar = roleStar });
+        encounterInfo.MonsterWaveList.Add(wave);
+        routeInfo.RouteEncounterList.Add(encounterInfo);
     }
 
     public bool TryEquipFromDraft(uint idx)
@@ -1170,6 +1926,33 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         return picks;
     }
 
+    /// <summary>
+    /// 判断战斗统计上报的 role_id 是否与出战角色匹配（兼容 AvatarID / 内部 RoleId）。
+    /// </summary>
+    private static bool MatchesBattleStatRoleId(uint reportedRoleId, uint roleKey)
+    {
+        if (reportedRoleId == 0 || roleKey == 0) return false;
+        if (reportedRoleId == roleKey) return true;
+        if (reportedRoleId == GridFightRoleLookup.ToSyncRoleId(roleKey)) return true;
+        if (reportedRoleId == GridFightRoleLookup.ToAvatarId(roleKey)) return true;
+        return reportedRoleId == GridFightRoleLookup.ToRoleId(roleKey);
+    }
+
+    /// <summary>
+    /// 根据战斗统计 role_id 查找对应出战角色（pos 1-13）。
+    /// </summary>
+    private (uint uniqueId, uint roleKey)? FindDeployedRoleByBattleStatId(uint reportedRoleId)
+    {
+        foreach (var (pos, uniqueId) in UniqueIdByPos.Where(kv => kv.Key is >= 1 and <= 13 && kv.Value != 0))
+        {
+            if (!RoleByUniqueId.TryGetValue(uniqueId, out var roleKey)) continue;
+            if (MatchesBattleStatRoleId(reportedRoleId, roleKey))
+                return (uniqueId, roleKey);
+        }
+
+        return null;
+    }
+
     public void RecordBattleSnapshot(PVEBattleResultCsReq req, bool win)
     {
         PreBattleLineupHp = LineupHp;
@@ -1186,12 +1969,19 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
             {
                 var roleId = entry.RoleId;
                 if (roleId == 0) continue;
+                var deployed = FindDeployedRoleByBattleStatId(roleId);
+                var syncRoleId = deployed != null
+                    ? GridFightRoleLookup.ToSyncRoleId(deployed.Value.roleKey)
+                    : GridFightRoleLookup.ToSyncRoleId(roleId);
+                var roleStar = deployed != null
+                    ? RoleStarByUniqueId.GetValueOrDefault(deployed.Value.uniqueId, 1u)
+                    : 1u;
                 var inActive = entry.Damage > 0 || entry.BOIEGPAPHOP > 0;
-                if (inActive) activeRoleIds.Add(roleId);
+                if (inActive) activeRoleIds.Add(syncRoleId);
                 LastBattleDamageStt.EABPCKEDDBH.Add(new HHHMMJBGCNG
                 {
-                    RoleId = roleId,
-                    RoleStar = 1,
+                    RoleId = syncRoleId,
+                    RoleStar = roleStar,
                     TotalDamage = entry.Damage,
                     LDMNBDIDFCC = inActive,
                     HNLEDBPGDBC = !inActive
@@ -1291,7 +2081,7 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
             HPOACJCPJHN = win,
             PACIAIJBOHO = KeepWinCnt,
             IDEAAPCCFPF = LastBattleIDEAAPCCFPF,
-            IPCFJBAKLCG = 10,
+            IPCFJBAKLCG = GetCurrentMaxBattleRoleNum(),
             MAGCGPMHHEA = PlayerMaxLevel,
             GCBBEEGANEG = new MIOMFOAEHEC
             {
@@ -1327,9 +2117,17 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         return GridFightBattleModule.StartBattle(Player, this);
     }
 
+    public uint LastConfiguredBattleSection { get; set; }
+
+    public bool NeedsBattleEncounterConfiguration()
+    {
+        return LastConfiguredBattleSection != SectionId;
+    }
+
     public void ConfigureNextBattle(uint stageId, IEnumerable<uint> monsterIds)
     {
         BattleComponent.SetEncounter(stageId, monsterIds);
+        LastConfiguredBattleSection = SectionId;
     }
 
     public async ValueTask EndBattle(BattleInstance battle, PVEBattleResultCsReq req)
@@ -1366,7 +2164,6 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         await Player.SendPacket(new PacketGridFightSyncUpdateResultScNotify(Player, GridFightSyncKind.PostBattle));
 
         OnBattleResolved(win);
-        await Player.SendPacket(new PacketGridFightSyncUpdateResultScNotify(Player, GridFightSyncKind.RefreshShop));
     }
 
     public GridFightCurrentInfo ToProto()
@@ -1437,15 +2234,15 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         GridBasicInfo = new GridFightGameBasicInfo
         {
             ANBBPPHBCJH = 3,
-            FLEJPPKLJIC = 3,
-            HAEOPKELNEO = 10,
+            FLEJPPKLJIC = PlayerLevel,
+            HAEOPKELNEO = GetCurrentMaxBattleRoleNum(),
             Gold = Gold,
-            GridFightBuyExpCost = 4,
+            GridFightBuyExpCost = GetBuyExpCost(),
             GridFightLineupHp = LineupHp,
             GridFightLineupMaxHp = LineupMaxHp,
             GridFightMaxAvatarCount = 9,
             GridFightMaxInterestGold = 5,
-            GridFightOffFieldMaxCount = 6,
+            GridFightOffFieldMaxCount = GetCurrentOffFieldMaxCount(),
             GridFightSyncCurtaskInfo = new GridFightSyncCurrentTaskInfo(),
             GameLockInfo = new GridFightLockInfo()
         }
@@ -1456,15 +2253,17 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         var team = new GridFightGameTeamInfo();
         foreach (var (pos, uniqueId) in UniqueIdByPos.OrderBy(kv => kv.Key))
         {
-            if (uniqueId == 0 || !RoleByUniqueId.TryGetValue(uniqueId, out var avatarId)) continue;
+            if (uniqueId == 0 || !RoleByUniqueId.TryGetValue(uniqueId, out var roleKey)) continue;
             team.GridGameRoleList.Add(new GridGameRoleInfo
             {
-                Id = avatarId,
+                Id = GridFightRoleLookup.ToSyncRoleId(roleKey),
                 Pos = pos,
                 RoleStar = RoleStarByUniqueId.GetValueOrDefault(uniqueId, 1u),
                 UniqueId = uniqueId
             });
         }
+
+        PopulatePrepRoleAugmentBindings(team);
         return new GridFightGameInfo { GridTraitGameInfo = team };
     }
 
@@ -1482,17 +2281,7 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
         {
             GLIFNMBMMBL = ShopRefreshLeft,
             DNOIFMMLJDN = { ShopRolePool },
-            LDEDGOOKHFL = new FJPONJFLOOH
-            {
-                EDJPMNLLGGB =
-                {
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 1, FLICPMGFKOK = 100 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 2 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 3 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 4 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 5 }
-                }
-            },
+            LDEDGOOKHFL = BuildShopRarityDisplayInfo(),
             ShopGoodsList = { ShopGoods }
         }
     };
@@ -1517,7 +2306,8 @@ public class GridFightInstance(PlayerInstance player, uint season, uint division
             SectionId = SectionId,
             ECCGJDMOGAN = new DDJIOFONKME(),
             BossInfo = new GridFightBossInfo(),
-            CMHBDMOJJEN = new IKFEDFBLOOG()
+            CMHBDMOJJEN = new IKFEDFBLOOG(),
+            GridFightLayerInfo = BuildCurrentLayerInfo()
         };
         EnsureSessionPreview();
         foreach (var campId in SessionCampIds)

--- a/GameServer/Game/GridFight/GridFightManager.cs
+++ b/GameServer/Game/GridFight/GridFightManager.cs
@@ -94,7 +94,15 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
         int kind = GridFightSyncKind.Bootstrap,
         object? extra = null)
     {
-        if (updatedPosList != null) return BuildPosUpdateSync(updatedPosList);
+        if (kind == GridFightSyncKind.PosUpdate)
+            return BuildPosUpdateSync(extra);
+        if (updatedPosList != null)
+        {
+            return BuildPosUpdateSync(new PosUpdateSyncPayload
+            {
+                UpdatedPosList = updatedPosList.ToList()
+            });
+        }
         return kind switch
         {
             GridFightSyncKind.Bootstrap      => BuildBootstrapSync(),
@@ -106,39 +114,214 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
             GridFightSyncKind.BuyExp         => BuildBuyExpSync(),
             GridFightSyncKind.PostBattle     => BuildPostBattleSync(),
             GridFightSyncKind.PreSettle      => BuildPreSettleSync(),
+            GridFightSyncKind.Preparation    => BuildPreparationStateSync(),
             GridFightSyncKind.NoOp           => new GridFightSyncUpdateResultScNotify(),
             _                                => new GridFightSyncUpdateResultScNotify()
         };
     }
 
-    private GridFightSyncUpdateResultScNotify BuildPosUpdateSync(IEnumerable<GridFightPosInfo> updatedPosList)
+    private GridFightSyncUpdateResultScNotify BuildPosUpdateSync(object? extra)
     {
         var notify = new GridFightSyncUpdateResultScNotify();
-        if (GridFightInstance == null) return notify;
-        var sync = new GridFightSyncResultData();
+        var inst = GridFightInstance;
+        if (inst == null) return notify;
+
+        List<GridFightPosInfo> updatedPosList = [];
+        List<GridFightInstance.RoleMergeResult> merges = [];
+        if (extra is PosUpdateSyncPayload payload)
+        {
+            updatedPosList = payload.UpdatedPosList;
+            merges = payload.Merges;
+        }
+        else if (extra is ValueTuple<IEnumerable<GridFightPosInfo>, List<GridFightInstance.RoleMergeResult>> tuple)
+        {
+            updatedPosList = tuple.Item1.ToList();
+            merges = tuple.Item2;
+        }
+        else if (extra is IEnumerable<GridFightPosInfo> list)
+        {
+            updatedPosList = list.ToList();
+        }
+
+        var sync = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpHndkhmefaal };
+        var synced = new HashSet<uint>();
         foreach (var posInfo in updatedPosList)
         {
-            if (posInfo.Pos == 0 || posInfo.UniqueId == 0) continue;
-            if (!GridFightInstance.RoleByUniqueId.TryGetValue(posInfo.UniqueId, out var avatarId)) continue;
-            var roleInfo = new GridGameRoleInfo
-            {
-                Id = avatarId,
-                Pos = posInfo.Pos,
-                UniqueId = posInfo.UniqueId,
-                RoleStar = GridFightInstance.RoleStarByUniqueId.GetValueOrDefault(posInfo.UniqueId, 1u)
-            };
-            if (GameData.GridFightRoleBasicInfoData.TryGetValue(avatarId, out var roleExcel)
-                && roleExcel.RoleSavedValueList.Count > 0)
-            {
-                roleInfo.GridFightValueInitComponent[roleExcel.RoleSavedValueList[0]] = 0;
-            }
+            if (posInfo.UniqueId == 0 || !synced.Add(posInfo.UniqueId)) continue;
+            var rolePos = posInfo.Pos > 0
+                ? posInfo.Pos
+                : inst.UniqueIdByPos.FirstOrDefault(kv => kv.Value == posInfo.UniqueId).Key;
+            if (rolePos == 0) continue;
             sync.UpdateDynamicList.Add(new GridFightSyncData
             {
-                UpdateRoleInfo = roleInfo
+                UpdateRoleInfo = inst.BuildGridGameRoleInfo(posInfo.UniqueId, rolePos)
             });
         }
+
         notify.SyncResultDataList.Add(sync);
         return notify;
+    }
+
+    /// <summary>
+    /// 构建升星过渡动画 sync（数据与粒子参数同段，不含 RemoveRoleUniqueId 与最终星级）。
+    /// </summary>
+    public GridFightSyncUpdateResultScNotify BuildRoleMergeAnimationNotify(
+        GridFightInstance.RoleMergeResult merge,
+        GridFightUpdateSrcType updateSrc)
+    {
+        var notify = new GridFightSyncUpdateResultScNotify();
+        var inst = GridFightInstance;
+        if (inst == null || !merge.Merged) return notify;
+
+        var sec = new GridFightSyncResultData
+        {
+            GridUpdateSrc = updateSrc,
+            SyncEffectParamList = { merge.KeptUniqueId, merge.NewStar }
+        };
+        AppendRoleMergeAnimationEntries(sec, inst, merge);
+        notify.SyncResultDataList.Add(sec);
+        return notify;
+    }
+
+    /// <summary>
+    /// 构建升星收尾 sync（移除消耗卡、写入最终星级并清理备战席空位）。
+    /// </summary>
+    public GridFightSyncUpdateResultScNotify BuildRoleMergeFinalizeNotify(
+        GridFightInstance.RoleMergeResult merge)
+    {
+        var notify = new GridFightSyncUpdateResultScNotify();
+        var inst = GridFightInstance;
+        if (inst == null || !merge.Merged) return notify;
+
+        var sec = new GridFightSyncResultData
+        {
+            GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpHndkhmefaal
+        };
+        AppendRoleMergeFinalizeEntries(sec, inst, merge);
+        AppendEmptyBenchSlotClears(sec, inst);
+        notify.SyncResultDataList.Add(sec);
+        return notify;
+    }
+
+    /// <summary>
+    /// 向 sync 段追加升星动画触发字段（不下发移除与最终星级，避免客户端瞬间跳变）。
+    /// </summary>
+    private static void AppendRoleMergeAnimationEntries(
+        GridFightSyncResultData sec,
+        GridFightInstance inst,
+        GridFightInstance.RoleMergeResult merge)
+    {
+        if (!merge.Merged) return;
+
+        var mergeCtx = new CMCJNKPKBEM();
+        foreach (var (uid, pos) in merge.ParticipantPosByUniqueId)
+            mergeCtx.CFNPGNMPNDN[uid.ToString()] = pos;
+
+        if (!merge.ParticipantPosByUniqueId.ContainsKey(merge.KeptUniqueId))
+        {
+            var keepPos = inst.UniqueIdByPos.FirstOrDefault(kv => kv.Value == merge.KeptUniqueId).Key;
+            if (keepPos > 0)
+                mergeCtx.CFNPGNMPNDN[merge.KeptUniqueId.ToString()] = keepPos;
+        }
+
+        sec.UpdateDynamicList.Add(new GridFightSyncData { CFNPGNMPNDN = mergeCtx });
+
+        foreach (var snapshot in merge.PreMergeRoleSnapshots.Values.OrderBy(s => s.Pos))
+            sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = snapshot });
+
+        sec.UpdateDynamicList.Add(new GridFightSyncData { HLFBBANMJDJ = merge.KeptUniqueId });
+        sec.UpdateDynamicList.Add(new GridFightSyncData { GDPBJDHGFLB = merge.NewStar });
+        sec.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            AJIMOAMGCII = GridFightRoleLookup.ToSyncRoleId(merge.RoleId)
+        });
+    }
+
+    /// <summary>
+    /// 向 sync 段追加升星收尾字段（移除消耗卡并同步保留卡最终星级）。
+    /// </summary>
+    private static void AppendRoleMergeFinalizeEntries(
+        GridFightSyncResultData sec,
+        GridFightInstance inst,
+        GridFightInstance.RoleMergeResult merge)
+    {
+        if (!merge.Merged) return;
+
+        foreach (var removedUid in merge.RemovedUniqueIds)
+            sec.UpdateDynamicList.Add(new GridFightSyncData { RemoveRoleUniqueId = removedUid });
+
+        var keeperInfo = merge.FinalKeeperRoleInfo ?? inst.BuildGridGameRoleInfo(merge.KeptUniqueId);
+        if (keeperInfo.UniqueId > 0)
+        {
+            sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = keeperInfo });
+        }
+    }
+
+    /// <summary>
+    /// 构建购买 AddRoleInfo；升星消耗购入卡时仍返回合成前快照，供客户端先看到三张参与卡。
+    /// </summary>
+    private static GridGameRoleInfo BuildPurchasedRoleAddInfo(
+        GridFightInstance inst,
+        uint roleUniqueId,
+        uint pos,
+        IEnumerable<GridFightInstance.RoleMergeResult> buyMerges)
+    {
+        foreach (var merge in buyMerges.Where(m => m.Merged))
+        {
+            if (merge.PreMergeRoleSnapshots.TryGetValue(roleUniqueId, out var snapshot))
+                return snapshot;
+        }
+
+        return inst.BuildGridGameRoleInfo(roleUniqueId, pos);
+    }
+
+    /// <summary>
+    /// 构建购买后备战席压缩 sync；升星参与卡改由动画包下发，避免提前写入最终星级。
+    /// </summary>
+    private static GridGameRoleInfo? TryBuildBenchRepositionRoleInfo(
+        GridFightInstance inst,
+        GridFightPosInfo benchPos,
+        IEnumerable<GridFightInstance.RoleMergeResult> buyMerges)
+    {
+        if (benchPos.UniqueId == 0 || !inst.RoleByUniqueId.ContainsKey(benchPos.UniqueId))
+            return null;
+
+        foreach (var merge in buyMerges.Where(m => m.Merged))
+        {
+            if (merge.RemovedUniqueIds.Contains(benchPos.UniqueId))
+                return null;
+            if (merge.ParticipantPosByUniqueId.ContainsKey(benchPos.UniqueId))
+                return null;
+        }
+
+        var roleInfo = inst.BuildGridGameRoleInfo(benchPos.UniqueId, benchPos.Pos);
+        return roleInfo.UniqueId == 0 ? null : roleInfo;
+    }
+
+    /// <summary>
+    /// 追加出战席布局 sync（MaxBattleRoleNum + GridFightOffFieldMaxCount，无条件 13 格）。
+    /// </summary>
+    private static void AppendBattlefieldMetaSync(GridFightSyncResultData sync, GridFightInstance inst) =>
+        GridFightInstance.AppendBattlefieldLayoutSync(sync, inst);
+
+    /// <summary>
+    /// 对备战席空位下发占位清除，避免客户端仍保留已移除角色的隐式占用。
+    /// </summary>
+    private static void AppendEmptyBenchSlotClears(GridFightSyncResultData sec, GridFightInstance inst)
+    {
+        var occupiedBenchPos = inst.UniqueIdByPos
+            .Where(kv => kv.Key is >= GridFightInstance.BenchPosMin and <= GridFightInstance.BenchPosMax && kv.Value != 0)
+            .Select(kv => kv.Key)
+            .ToHashSet();
+
+        for (uint pos = GridFightInstance.BenchPosMin; pos <= GridFightInstance.BenchPosMax; pos++)
+        {
+            if (occupiedBenchPos.Contains(pos)) continue;
+            sec.UpdateDynamicList.Add(new GridFightSyncData
+            {
+                UpdateRoleInfo = new GridGameRoleInfo { Pos = pos, UniqueId = 0, Id = 0, RoleStar = 0 }
+            });
+        }
     }
 
     private GridFightSyncUpdateResultScNotify BuildPendingAdvanceSync(object? extra)
@@ -171,6 +354,101 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
             notify.SyncResultDataList.Add(pendingSync);
         }
         return notify;
+    }
+
+    /// <summary>
+    /// Pushes gold, HP, chapter/section, shop and deployment cap when entering preparation.
+    /// </summary>
+    private GridFightSyncUpdateResultScNotify BuildPreparationStateSync()
+    {
+        var notify = new GridFightSyncUpdateResultScNotify();
+        var inst = GridFightInstance;
+        if (inst == null) return notify;
+
+        notify.SyncResultDataList.Add(BuildPreparationSyncResultData(inst));
+        return notify;
+    }
+
+    /// <summary>
+    /// 构建返回备战界面的合并 sync：解锁、完整备战状态、商店打开段（单包下发，避免自动开商店时状态不同步）。
+    /// </summary>
+    public GridFightSyncUpdateResultScNotify BuildReturnPreparationNotify(uint ackPos)
+    {
+        var notify = new GridFightSyncUpdateResultScNotify();
+        var inst = GridFightInstance;
+        if (inst == null) return notify;
+
+        EnsureNextBattleConfigured(inst);
+
+        var finishSync = new GridFightSyncResultData();
+        finishSync.UpdateDynamicList.Add(new GridFightSyncData { FinishPendingActionPos = ackPos });
+        finishSync.UpdateDynamicList.Add(new GridFightSyncData { SyncLockInfo = new GridFightLockInfo() });
+        notify.SyncResultDataList.Add(finishSync);
+        notify.SyncResultDataList.Add(BuildPreparationSyncResultData(inst));
+        notify.SyncResultDataList.Add(BuildShopOpenSyncResultData(inst));
+        return notify;
+    }
+
+    /// <summary>
+    /// 在下发备战 sync 前解析并缓存下一战遭遇，确保节点地图与商店 UI 绑定正确关卡。
+    /// </summary>
+    private static void EnsureNextBattleConfigured(GridFightInstance inst)
+    {
+        if (!GridFightLevelResolver.IsCombatNode(inst) || !inst.NeedsBattleEncounterConfiguration())
+            return;
+
+        var encounter = GridFightLevelResolver.Resolve(inst);
+        inst.ConfigureNextBattle(encounter.StageId, encounter.Monsters.Select(m => m.MonsterId));
+    }
+
+    /// <summary>
+    /// 构建进入备战阶段的完整状态 sync 段。
+    /// </summary>
+    private GridFightSyncResultData BuildPreparationSyncResultData(GridFightInstance inst)
+    {
+        var sync = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpEjkejdnhioe };
+        sync.UpdateDynamicList.Add(new GridFightSyncData { ItemValue = inst.Gold });
+        sync.UpdateDynamicList.Add(new GridFightSyncData { ShopSyncInfo = BuildShopSyncInfo(inst) });
+        sync.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            GridFightLineupHp = new GridFightLineupHpSyncInfo
+            {
+                GridFightLineupHp = inst.LineupHp,
+                GridFightLineupMaxHp = inst.LineupMaxHp
+            }
+        });
+        sync.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            LevelSyncInfo = new GridFightLevelSyncInfo
+            {
+                DCPKPNLKGMM = inst.CurrentChapterId,
+                SectionId = inst.SectionId,
+                GridFightLayerInfo = inst.BuildCurrentLayerInfo()
+            }
+        });
+        sync.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            PlayerLevel = new GridFightPlayerLevelSyncInfo
+            {
+                Level = inst.PlayerLevel,
+                Exp = inst.PlayerExp,
+                MaxLevel = inst.PlayerMaxLevel
+            }
+        });
+        AppendBattlefieldMetaSync(sync, inst);
+        return sync;
+    }
+
+    /// <summary>
+    /// 构建客户端打开商店界面所需的 sync 段（与购买后刷新商店格式一致）。
+    /// </summary>
+    private GridFightSyncResultData BuildShopOpenSyncResultData(GridFightInstance inst)
+    {
+        var sync = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpDpekjiiicgh };
+        sync.SyncEffectParamList.Add(0u);
+        sync.UpdateDynamicList.Add(new GridFightSyncData { ItemValue = inst.Gold });
+        sync.UpdateDynamicList.Add(new GridFightSyncData { ShopSyncInfo = BuildShopSyncInfo(inst) });
+        return sync;
     }
 
     private GridFightSyncUpdateResultScNotify BuildSelectEquipSync(object? extra)
@@ -206,22 +484,45 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
             notify.SyncResultDataList.Add(new GridFightSyncResultData());
             return notify;
         }
+
         uint roleId;
         uint roleUniqueId;
         uint pos;
-        List<uint> mergedRemoved;
-        uint mergedKeepUid;
-        uint mergedNewStar;
-        if (extra is ValueTuple<uint, uint, uint, int, List<uint>, uint, uint> v2)
+        List<GridFightInstance.RoleMergeResult> buyMerges = [];
+        List<GridFightPosInfo> benchRepositions = [];
+        uint shopIndex = 0;
+        uint purchasedAugmentId = 0;
+        uint purchasedAugmentTargetUniqueId = 0;
+        if (extra is BuyGoodsSyncPayload payload)
         {
-            (roleId, roleUniqueId, pos, _, mergedRemoved, mergedKeepUid, mergedNewStar) = v2;
+            roleId = payload.RoleId;
+            roleUniqueId = payload.RoleUniqueId;
+            pos = payload.Pos;
+            buyMerges = payload.Merges;
+            benchRepositions = payload.BenchRepositions;
+            shopIndex = payload.ShopIndex;
+            purchasedAugmentId = payload.PurchasedAugmentId;
+            purchasedAugmentTargetUniqueId = payload.PurchasedAugmentTargetUniqueId;
+        }
+        else if (extra is ValueTuple<uint, uint, uint, int, List<uint>, uint, uint> v2)
+        {
+            (roleId, roleUniqueId, pos, _, var mergedRemoved, var mergedKeepUid, _) = v2;
+            if (mergedRemoved.Count > 0 && mergedKeepUid > 0)
+            {
+                var legacyMerge = new GridFightInstance.RoleMergeResult
+                {
+                    KeptUniqueId = mergedKeepUid,
+                    NewStar = inst.RoleStarByUniqueId.GetValueOrDefault(mergedKeepUid, 1u),
+                    RoleId = roleId
+                };
+                foreach (var uid in mergedRemoved)
+                    legacyMerge.RemovedUniqueIds.Add(uid);
+                buyMerges.Add(legacyMerge);
+            }
         }
         else if (extra is ValueTuple<uint, uint, uint, int> v1)
         {
             (roleId, roleUniqueId, pos, _) = v1;
-            mergedRemoved = [];
-            mergedKeepUid = 0;
-            mergedNewStar = 0;
         }
         else
         {
@@ -230,53 +531,45 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
         }
 
         var sec0 = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpDpekjiiicgh };
-        sec0.SyncEffectParamList.Add(0u);
+        sec0.SyncEffectParamList.Add(shopIndex);
         sec0.UpdateDynamicList.Add(new GridFightSyncData { ItemValue = inst.Gold });
+        foreach (var benchPos in benchRepositions)
+        {
+            var roleInfo = TryBuildBenchRepositionRoleInfo(inst, benchPos, buyMerges);
+            if (roleInfo == null) continue;
+            sec0.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = roleInfo });
+        }
         if (roleUniqueId > 0)
         {
-            if (mergedRemoved.Count == 0 || mergedKeepUid == 0)
+            sec0.UpdateDynamicList.Add(new GridFightSyncData
             {
-                var roleInfo = new GridGameRoleInfo
-                {
-                    Id = roleId,
-                    Pos = pos,
-                    RoleStar = 1,
-                    UniqueId = roleUniqueId
-                };
-                if (GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var roleExcel)
-                    && roleExcel.RoleSavedValueList.Count > 0)
-                {
-                    roleInfo.GridFightValueInitComponent[roleExcel.RoleSavedValueList[0]] = 0;
-                }
-                sec0.UpdateDynamicList.Add(new GridFightSyncData { AddRoleInfo = roleInfo });
-            }
-            else
-            {
-                foreach (var removedUid in mergedRemoved)
-                    sec0.UpdateDynamicList.Add(new GridFightSyncData { RemoveRoleUniqueId = removedUid });
-
-                var keepPos = inst.UniqueIdByPos.FirstOrDefault(kv => kv.Value == mergedKeepUid).Key;
-                var mergedRole = new GridGameRoleInfo
-                {
-                    Id = roleId,
-                    Pos = keepPos,
-                    RoleStar = mergedNewStar,
-                    UniqueId = mergedKeepUid
-                };
-                if (GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var roleExcel)
-                    && roleExcel.RoleSavedValueList.Count > 0)
-                {
-                    mergedRole.GridFightValueInitComponent[roleExcel.RoleSavedValueList[0]] = 0;
-                }
-
-                
-                
-                if (mergedKeepUid == roleUniqueId)
-                    sec0.UpdateDynamicList.Add(new GridFightSyncData { AddRoleInfo = mergedRole });
-                else
-                    sec0.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = mergedRole });
-            }
+                AddRoleInfo = BuildPurchasedRoleAddInfo(inst, roleUniqueId, pos, buyMerges)
+            });
         }
+
+        if (purchasedAugmentId > 0 && purchasedAugmentTargetUniqueId > 0)
+        {
+            sec0.UpdateDynamicList.Add(new GridFightSyncData { HLFBBANMJDJ = purchasedAugmentTargetUniqueId });
+            sec0.UpdateDynamicList.Add(new GridFightSyncData
+            {
+                UpdateRoleInfo = inst.BuildGridGameRoleInfo(purchasedAugmentTargetUniqueId)
+            });
+            sec0.UpdateDynamicList.Add(new GridFightSyncData
+            {
+                GridGameAugmentUpdate = new GridFightGameAugmentUpdate
+                {
+                    UpdateAugmentInfo = new GridGameAugmentInfo
+                    {
+                        AugmentId = purchasedAugmentId,
+                        NDCFBKJDPAH = true,
+                        MHMLMKDFJLN = true
+                    }
+                }
+            });
+            GridFightInstance.AppendRoleAugmentBindingSync(sec0, inst, purchasedAugmentTargetUniqueId, purchasedAugmentId);
+        }
+
+        AppendBattlefieldMetaSync(sec0, inst);
         notify.SyncResultDataList.Add(sec0);
 
         var sec1 = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpDpekjiiicgh };
@@ -287,22 +580,29 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
         return notify;
     }
 
+    /// <summary>
+    /// 构建商店刷新 sync（syncEffectParam：0 常规，1 免费刷新动画）。
+    /// </summary>
+    public GridFightSyncUpdateResultScNotify BuildShopRefreshNotify(uint syncEffectParam = 0)
+    {
+        var notify = new GridFightSyncUpdateResultScNotify();
+        var inst = GridFightInstance;
+        if (inst == null) return notify;
+
+        var sec = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpDpekjiiicgh };
+        sec.SyncEffectParamList.Add(syncEffectParam);
+        sec.UpdateDynamicList.Add(new GridFightSyncData { ItemValue = inst.Gold });
+        sec.UpdateDynamicList.Add(new GridFightSyncData { ShopSyncInfo = BuildShopSyncInfo(inst) });
+        notify.SyncResultDataList.Add(sec);
+        return notify;
+    }
+
     private static GridFightShopSyncInfo BuildShopSyncInfo(GridFightInstance inst)
     {
         var shopSync = new GridFightShopSyncInfo
         {
             GLIFNMBMMBL = inst.ShopRefreshLeft,
-            LDEDGOOKHFL = new FJPONJFLOOH
-            {
-                EDJPMNLLGGB =
-                {
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 1, FLICPMGFKOK = 100 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 2 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 3 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 4 },
-                    new MJJEHCBNOKI { MMKNFIFOPPA = 5 }
-                }
-            }
+            LDEDGOOKHFL = inst.BuildShopRarityDisplayInfo(),
         };
         foreach (var goods in inst.ShopGoods)
             shopSync.ShopGoodsList.Add(goods);
@@ -357,9 +657,10 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
             {
                 GridFightBuyExpCost = inst.GetBuyExpCost()
             });
+            GridFightInstance.AppendBattlefieldLayoutSync(sync, inst);
             sync.UpdateDynamicList.Add(new GridFightSyncData
             {
-                MaxBattleRoleNum = inst.GetCurrentMaxBattleRoleNum()
+                ShopSyncInfo = new GridFightShopSyncInfo { LDEDGOOKHFL = inst.BuildShopRarityDisplayInfo() }
             });
         }
         notify.SyncResultDataList.Add(sync);
@@ -608,10 +909,10 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
             foreach (var (pos, uniqueId) in inst.UniqueIdByPos.OrderBy(kv => kv.Key))
             {
                 if (pos == 0 || pos > 13) continue;
-                if (uniqueId == 0 || !inst.RoleByUniqueId.TryGetValue(uniqueId, out var roleId)) continue;
+                if (uniqueId == 0 || !inst.RoleByUniqueId.TryGetValue(uniqueId, out var roleKey)) continue;
                 notify.EDKJMPACHNJ.GridGameRoleList.Add(new GridGameRoleInfo
                 {
-                    Id = roleId,
+                    Id = GridFightRoleLookup.ToSyncRoleId(roleKey),
                     Pos = pos,
                     UniqueId = uniqueId,
                     RoleStar = inst.RoleStarByUniqueId.GetValueOrDefault(uniqueId, 1u)
@@ -652,6 +953,7 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
 
         GridFightInstance = new GridFightInstance(Player, season == 0 ? 1u : season,
             divisionId == 0 ? MaxDivisionId() : divisionId, isOverLock, ++CurUniqueId);
+        GridFightInstance.EnsureRouteBinding();
         return (Retcode.RetSucc, GridFightInstance);
     }
 }

--- a/GameServer/Game/GridFight/GridFightManager.cs
+++ b/GameServer/Game/GridFight/GridFightManager.cs
@@ -258,9 +258,9 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
     }
 
     /// <summary>
-    /// 构建购买 AddRoleInfo；升星消耗购入卡时仍返回合成前快照，供客户端先看到三张参与卡。
+    /// 构建购买/复制 AddRoleInfo；升星消耗新卡时仍返回合成前快照，供客户端先看到三张参与卡。
     /// </summary>
-    private static GridGameRoleInfo BuildPurchasedRoleAddInfo(
+    public static GridGameRoleInfo BuildPurchasedRoleAddInfo(
         GridFightInstance inst,
         uint roleUniqueId,
         uint pos,
@@ -276,9 +276,9 @@ public class GridFightManager(PlayerInstance player) : BasePlayerManager(player)
     }
 
     /// <summary>
-    /// 构建购买后备战席压缩 sync；升星参与卡改由动画包下发，避免提前写入最终星级。
+    /// 构建购买/复制后备战席压缩 sync；升星参与卡改由动画包下发，避免提前写入最终星级。
     /// </summary>
-    private static GridGameRoleInfo? TryBuildBenchRepositionRoleInfo(
+    public static GridGameRoleInfo? TryBuildBenchRepositionRoleInfo(
         GridFightInstance inst,
         GridFightPosInfo benchPos,
         IEnumerable<GridFightInstance.RoleMergeResult> buyMerges)

--- a/GameServer/Game/GridFight/GridFightMergeSyncHelper.cs
+++ b/GameServer/Game/GridFight/GridFightMergeSyncHelper.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using March7thHoney.GameServer.Game.Player;
+using March7thHoney.GameServer.Server;
+using March7thHoney.GameServer.Server.Packet.Send.GridFight;
+using March7thHoney.Kcp;
+using March7thHoney.Proto;
+
+namespace March7thHoney.GameServer.Game.GridFight;
+
+/// <summary>
+/// 升星动画 sync 的统一发送入口。
+/// </summary>
+public static class GridFightMergeSyncHelper
+{
+    /// <summary>
+    /// 发送升星动画与收尾 sync 包。
+    /// </summary>
+    public static async System.Threading.Tasks.Task SendMergeSyncsAsync(
+        Connection connection,
+        PlayerInstance player,
+        IEnumerable<GridFightInstance.RoleMergeResult> merges,
+        GridFightUpdateSrcType mergeAnimationSrc)
+    {
+        var manager = player.GridFightManager!;
+        var inst = manager.GridFightInstance;
+        if (inst == null) return;
+
+        foreach (var merge in merges.Where(m => m.Merged))
+        {
+            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(
+                manager.BuildRoleMergeAnimationNotify(merge, mergeAnimationSrc)));
+            await System.Threading.Tasks.Task.Yield();
+            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(
+                manager.BuildRoleMergeFinalizeNotify(merge)));
+        }
+    }
+}

--- a/GameServer/Game/GridFight/GridFightService.cs
+++ b/GameServer/Game/GridFight/GridFightService.cs
@@ -15,8 +15,12 @@ public sealed class GridFightService(PlayerInstance player)
         return inst!;
     }
 
+    /// <summary>
+    /// 开启新对局并重置实例，确保 portal 选择等开局 pending 从 queue 1 开始。
+    /// </summary>
     public GridFightInstance StartAndPrepare(uint season, uint divisionId, bool isOverlock)
     {
+        Manager.GridFightInstance = null;
         var inst = EnsureOrStart(season, divisionId, isOverlock);
         if (inst.PendingAction == null)
         {
@@ -33,26 +37,82 @@ public sealed class GridFightService(PlayerInstance player)
         return inst;
     }
 
-    public List<GridFightPosInfo> UpdatePos(IEnumerable<GridFightPosInfo> posInfoList)
+    /// <summary>
+    /// 应用走位并在成功后尝试升星合成。
+    /// </summary>
+    public (List<GridFightPosInfo> accepted, Retcode retcode, List<GridFightInstance.RoleMergeResult> merges, List<GridFightPosInfo> syncPosList) UpdatePos(
+        IEnumerable<GridFightPosInfo> posInfoList)
     {
-        var inst = Current;
         var list = posInfoList.ToList();
-        inst?.ApplyPositionList(list);
-        return list;
+        var inst = Current;
+        if (inst == null)
+            return ([], Retcode.RetGridFightNotInGameplay, [], []);
+
+        var (retcode, affected) = inst.TryValidateAndApplyPositionList(list);
+        if (retcode != Retcode.RetSucc)
+            return ([], retcode, [], []);
+
+        var merges = inst.TryAutoMergeAllRoles();
+        var benchMoved = merges.Count > 0 ? inst.FinalizeBenchAfterMerge() : [];
+        var syncPosList = MergePosUpdates(affected, benchMoved);
+
+        return (list, Retcode.RetSucc, merges, syncPosList);
     }
 
-    public (uint roleId, uint roleUniqueId, uint pos, int goldDelta, List<uint> mergedRemoved, uint mergedKeepUid, uint mergedNewStar) BuyGoods(IList<uint> buyGoodsIndexList)
+    /// <summary>
+    /// 合并走位 sync 列表与升星后备战席压缩结果。
+    /// </summary>
+    private static List<GridFightPosInfo> MergePosUpdates(
+        List<GridFightPosInfo> current,
+        List<GridFightPosInfo> extra)
+    {
+        var merged = new Dictionary<uint, uint>();
+        foreach (var pos in current.Concat(extra))
+        {
+            if (pos.UniqueId == 0) continue;
+            merged[pos.UniqueId] = pos.Pos;
+        }
+
+        return merged.Select(kv => new GridFightPosInfo { UniqueId = kv.Key, Pos = kv.Value }).ToList();
+    }
+
+    public (uint roleId, uint roleUniqueId, uint pos, int goldDelta, List<GridFightInstance.RoleMergeResult> merges, List<GridFightPosInfo> benchMoved, bool duplicateRetry, uint purchasedAugmentId, uint purchasedAugmentTargetUniqueId, Retcode retcode) BuyGoods(IList<uint> buyGoodsIndexList)
     {
         var inst = Current;
         if (inst == null || buyGoodsIndexList.Count == 0)
-            return (0, 0, 14, 0, [], 0, 0);
+            return (0, 0, 14, 0, [], [], false, 0, 0, Retcode.RetGridFightNotInGameplay);
 
         var idx = (int)buyGoodsIndexList[0];
-        var (ok, uid, rid, addedPos) = inst.TryBuyGoods(idx);
-        if (!ok) return (0, 0, 14, 0, [], 0, 0);
+        var (ok, uid, rid, addedPos, benchMoved, duplicateRetry, purchasedAugmentId, retcode) = inst.TryBuyGoods(idx);
+        if (!ok) return (0, 0, 14, 0, [], benchMoved, false, 0, 0, retcode);
 
-        var merge = inst.TryAutoMergeRole(rid, uid);
-        return (rid, uid, addedPos == 0 ? 14u : addedPos, -1, merge.RemovedUniqueIds, merge.KeptUniqueId, merge.NewStar);
+        var merges = duplicateRetry || purchasedAugmentId > 0
+            ? []
+            : inst.TryAutoMergeAllRoles();
+        if (!duplicateRetry && merges.Count > 0)
+        {
+            inst.LastBoughtUniqueId = merges[^1].KeptUniqueId;
+            benchMoved = MergeBenchRepositions(benchMoved, inst.FinalizeBenchAfterMerge());
+        }
+
+        return (rid, uid, addedPos, duplicateRetry ? 0 : -1, merges, benchMoved, duplicateRetry, purchasedAugmentId, inst.LastSpecialGoodsTargetUniqueId, Retcode.RetSucc);
+    }
+
+    /// <summary>
+    /// 合并备战席压缩结果，避免同一角色重复条目。
+    /// </summary>
+    private static List<GridFightPosInfo> MergeBenchRepositions(
+        List<GridFightPosInfo> current,
+        List<GridFightPosInfo> extra)
+    {
+        var merged = new Dictionary<uint, uint>();
+        foreach (var pos in current.Concat(extra))
+        {
+            if (pos.UniqueId == 0) continue;
+            merged[pos.UniqueId] = pos.Pos;
+        }
+
+        return merged.Select(kv => new GridFightPosInfo { UniqueId = kv.Key, Pos = kv.Value }).ToList();
     }
 
     public bool RefreshShop()

--- a/GameServer/Game/GridFight/PendingAction/GridFightPendingActionProcessor.cs
+++ b/GameServer/Game/GridFight/PendingAction/GridFightPendingActionProcessor.cs
@@ -10,16 +10,64 @@ namespace March7thHoney.GameServer.Game.GridFight.PendingAction;
 
 public static class GridFightPendingActionProcessor
 {
+    /// <summary>
+    /// 处理客户端 pending 操作；队列位置不匹配时仅重推当前状态，避免重复结算。
+    /// </summary>
     public static async System.Threading.Tasks.Task Handle(Connection connection, GridFightInstance inst, GridFightSelectRecommendEquipCsReq req)
     {
         var ackPos = req.QueuePosition;
+
+        if (inst.PendingAction == null)
+        {
+            await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
+            return;
+        }
+
+        if (ackPos != inst.PendingAction.QueuePosition)
+        {
+            if (req.PortalBuffAction != null
+                && ackPos < inst.PendingAction.QueuePosition
+                && inst.IsPortalBuffSelectionPending())
+            {
+                await HandlePortalBuffSelect(connection, inst, ackPos, req.PortalBuffAction.SelectPortalBuffId);
+                return;
+            }
+
+            if (req.PortalBuffAction != null && inst.InitialBenchRolesSynced && ackPos < inst.PendingAction.QueuePosition)
+            {
+                await ResyncPortalBuffCompleted(connection, inst, ackPos);
+                return;
+            }
+
+            await ResyncPendingAction(connection, inst, ackPos);
+            return;
+        }
+
         if (req.PortalBuffRerollAction != null)
         {
+            if (inst.PendingAction.PortalBuffAction == null)
+            {
+                await ResyncPendingAction(connection, inst, ackPos);
+                return;
+            }
+
             await HandlePortalBuffReroll(connection, inst, ackPos);
             return;
         }
         if (req.PortalBuffAction != null)
         {
+            if (inst.PendingAction.PortalBuffAction == null)
+            {
+                if (inst.InitialBenchRolesSynced)
+                {
+                    await ResyncPortalBuffCompleted(connection, inst, ackPos);
+                    return;
+                }
+
+                await ResyncPendingAction(connection, inst, ackPos);
+                return;
+            }
+
             await HandlePortalBuffSelect(connection, inst, ackPos, req.PortalBuffAction.SelectPortalBuffId);
             return;
         }
@@ -53,6 +101,14 @@ public static class GridFightPendingActionProcessor
             await HandleEliteBranchSelect(connection, inst, ackPos, req.EliteBranchAction.EliteBranchId);
             return;
         }
+        if (inst.PendingAction.TraitAction != null)
+        {
+            if (req.TraitAction != null)
+                await GridFightHeadPlayerService.HandleTraitActionAsync(connection, inst, ackPos, req.TraitAction);
+            else
+                await GridFightHeadPlayerService.ResyncTraitPendingPublic(connection, inst, ackPos);
+            return;
+        }
         if (req.RoundBeginAction != null)
         {
             await HandleRoundBegin(connection, inst, ackPos);
@@ -64,6 +120,12 @@ public static class GridFightPendingActionProcessor
             return;
         }
 
+        if (inst.IsPortalBuffSelectionPending())
+        {
+            await ResyncPendingAction(connection, inst, ackPos);
+            return;
+        }
+
         inst.QueuePosition = ackPos + 1;
         inst.PendingAction = new GridFightPendingAction
         {
@@ -72,6 +134,76 @@ public static class GridFightPendingActionProcessor
         };
         await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
         await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(connection.Player!, GridFightSyncKind.PendingAdvance, (ackPos, inst.QueuePosition)));
+    }
+
+    /// <summary>
+    /// 向客户端重推当前 pending 状态，用于重复或过期请求。
+    /// </summary>
+    private static async System.Threading.Tasks.Task ResyncPendingAction(Connection connection, GridFightInstance inst, uint ackPos)
+    {
+        if (inst.PendingAction != null && ackPos < inst.PendingAction.QueuePosition)
+        {
+            await ResyncPortalBuffCompleted(connection, inst, ackPos);
+            return;
+        }
+
+        await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
+
+        if (inst.PendingAction == null) return;
+
+        var sync = new GridFightSyncUpdateResultScNotify();
+        var sec = new GridFightSyncResultData();
+        sec.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            SyncLockInfo = new GridFightLockInfo
+            {
+                LockReason = GridFightLockReason.DfofffceffoKjmjdbjmbmc,
+                LockType = GridFightLockType.PjbmhhnlclbEhfhdgpocnh
+            }
+        });
+        sec.UpdateDynamicList.Add(new GridFightSyncData { PendingAction = inst.PendingAction });
+        sync.SyncResultDataList.Add(sec);
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
+    }
+
+    /// <summary>
+    /// 投资环境已结算但客户端仍重复提交时，补发完整 portal 完成 sync（含 buff、角色、关卡）。
+    /// </summary>
+    private static async System.Threading.Tasks.Task ResyncPortalBuffCompleted(Connection connection, GridFightInstance inst, uint ackPos)
+    {
+        if (inst.ActivePortalBuffIds.Count > 0)
+        {
+            var buffId = inst.ActivePortalBuffIds[^1];
+            var sync = BuildPortalBuffSelectSync(inst, ackPos, buffId, replayOnly: true);
+            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
+            await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
+            return;
+        }
+
+        var fallback = new GridFightSyncUpdateResultScNotify();
+
+        var finishSec = new GridFightSyncResultData();
+        finishSec.UpdateDynamicList.Add(new GridFightSyncData { FinishPendingActionPos = ackPos });
+        finishSec.UpdateDynamicList.Add(new GridFightSyncData { SyncLockInfo = new GridFightLockInfo() });
+        fallback.SyncResultDataList.Add(finishSec);
+
+        if (inst.PendingAction != null)
+        {
+            var pendingSec = new GridFightSyncResultData();
+            pendingSec.UpdateDynamicList.Add(new GridFightSyncData
+            {
+                SyncLockInfo = new GridFightLockInfo
+                {
+                    LockReason = GridFightLockReason.DfofffceffoKjmjdbjmbmc,
+                    LockType = GridFightLockType.PjbmhhnlclbEhfhdgpocnh
+                }
+            });
+            pendingSec.UpdateDynamicList.Add(new GridFightSyncData { PendingAction = inst.PendingAction });
+            fallback.SyncResultDataList.Add(pendingSec);
+        }
+
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(fallback));
+        await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
     }
 
     private static async System.Threading.Tasks.Task HandlePortalBuffReroll(Connection connection, GridFightInstance inst, uint ackPos)
@@ -98,38 +230,66 @@ public static class GridFightPendingActionProcessor
 
     private static async System.Threading.Tasks.Task HandlePortalBuffSelect(Connection connection, GridFightInstance inst, uint ackPos, uint buffId)
     {
-        if (buffId > 0 && !inst.ActivePortalBuffIds.Contains(buffId)) inst.ActivePortalBuffIds.Add(buffId);
-        inst.ClearPortalBuffOffer();
-
-        uint requiredTrait = 0;
-        if (GameData.GridFightPortalBuffData.TryGetValue(buffId, out var buffData)
-            && buffData.PortalGameRefTrait.Count > 0)
+        if (buffId == 0)
         {
-            requiredTrait = buffData.PortalGameRefTrait[0];
+            await ResyncPendingAction(connection, inst, ackPos);
+            return;
         }
-        inst.MaterializeInitialBenchTeam(requiredTrait);
-        var encounter = GridFightLevelResolver.Resolve(inst);
-        inst.ConfigureNextBattle(encounter.StageId, encounter.Monsters.Select(m => m.MonsterId));
 
-        var nextPos = ackPos + 1;
-        inst.QueuePosition = nextPos;
-        inst.PendingAction = new GridFightPendingAction
+        var offer = inst.EnsurePortalBuffOffer();
+        if (offer.Count > 0 && !offer.Contains(buffId) && !inst.ActivePortalBuffIds.Contains(buffId))
         {
-            QueuePosition = nextPos,
-            RoundBeginAction = new GridFightRoundBeginActionInfo()
-        };
+            await ResyncPendingAction(connection, inst, ackPos);
+            return;
+        }
+
+        if (inst.IsPortalBuffSelectionPending())
+        {
+            if (buffId > 0 && !inst.ActivePortalBuffIds.Contains(buffId)) inst.ActivePortalBuffIds.Add(buffId);
+            inst.ClearPortalBuffOffer();
+
+            uint requiredTrait = 0;
+            if (GameData.GridFightPortalBuffData.TryGetValue(buffId, out var buffData)
+                && buffData.PortalGameRefTrait.Count > 0)
+            {
+                requiredTrait = buffData.PortalGameRefTrait[0];
+            }
+            inst.MaterializeInitialBenchTeam(requiredTrait);
+            var encounter = GridFightLevelResolver.Resolve(inst);
+            inst.ConfigureNextBattle(encounter.StageId, encounter.Monsters.Select(m => m.MonsterId));
+
+            var nextPos = ackPos + 1;
+            inst.QueuePosition = nextPos;
+            inst.PendingAction = new GridFightPendingAction
+            {
+                QueuePosition = nextPos,
+                RoundBeginAction = new GridFightRoundBeginActionInfo()
+            };
+
+            if (!inst.InitialBenchRolesSynced)
+                inst.InitialBenchRolesSynced = true;
+        }
 
         var handbook = new GridFightSeasonHandBookNotify { HandbookGridFightPortalInfo = new GridFightHandBookPortalInfo() };
         handbook.HandbookGridFightPortalInfo.GridFightPortalBuffList.Add(buffId);
+
+        var sync = BuildPortalBuffSelectSync(inst, ackPos, buffId, replayOnly: false);
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
         await connection.SendPacket(new PacketGridFightSeasonHandBookNotify(handbook));
         await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
+    }
 
+    /// <summary>
+    /// 构建 portal buff 选择完成后的 sync 包；replayOnly 为 true 时不重复写入实例状态。
+    /// </summary>
+    private static GridFightSyncUpdateResultScNotify BuildPortalBuffSelectSync(
+        GridFightInstance inst, uint ackPos, uint buffId, bool replayOnly)
+    {
         var sync = new GridFightSyncUpdateResultScNotify();
 
         var grantedEquipIds = new List<uint>();
         if (GameData.GridFightPortalBuffData.TryGetValue(buffId, out var portalBuffData))
         {
-            
             foreach (var bonusId in portalBuffData.ShowBonusIDList)
             {
                 if (GameData.GridFightEquipmentData.ContainsKey(bonusId))
@@ -144,6 +304,15 @@ public static class GridFightPendingActionProcessor
             var addItemInfo = new GridFightGameItemSyncInfo();
             foreach (var equipId in grantedEquipIds)
             {
+                var existing = inst.Equipments.FirstOrDefault(e => e.GridFightEquipmentId == equipId);
+                if (existing != null)
+                {
+                    addItemInfo.GridFightEquipmentList.Add(existing);
+                    continue;
+                }
+
+                if (replayOnly) continue;
+
                 var equip = new GridFightEquipmentInfo
                 {
                     GridFightEquipmentId = equipId,
@@ -153,8 +322,11 @@ public static class GridFightPendingActionProcessor
                 inst.Equipments.Add(equip);
                 addItemInfo.GridFightEquipmentList.Add(equip);
             }
-            sec0.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItemInfo });
-            sync.SyncResultDataList.Add(sec0);
+            if (addItemInfo.GridFightEquipmentList.Count > 0)
+            {
+                sec0.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItemInfo });
+                sync.SyncResultDataList.Add(sec0);
+            }
         }
 
         var sec2 = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpHndkhmefaal };
@@ -170,6 +342,7 @@ public static class GridFightPendingActionProcessor
                 AddRoleInfo = new GridGameRoleInfo { Id = avatarId, Pos = pos, RoleStar = 1, UniqueId = uniqueId, GridFightValueInitComponent = { [component] = 0 } }
             });
         }
+        GridFightInstance.AppendBattlefieldLayoutSync(sec3, inst);
         sync.SyncResultDataList.Add(sec3);
 
         var sec4 = new GridFightSyncResultData();
@@ -223,22 +396,23 @@ public static class GridFightPendingActionProcessor
                 LockType = GridFightLockType.PjbmhhnlclbEhfhdgpocnh
             }
         });
-        sec6.UpdateDynamicList.Add(new GridFightSyncData { PendingAction = inst.PendingAction });
+        if (inst.PendingAction != null)
+            sec6.UpdateDynamicList.Add(new GridFightSyncData { PendingAction = inst.PendingAction });
         sync.SyncResultDataList.Add(sec6);
-        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
+
+        return sync;
     }
 
     private static async System.Threading.Tasks.Task HandleRoundBegin(Connection connection, GridFightInstance inst, uint ackPos)
     {
-        inst.RotateShop();
         var nextPos = ackPos + 1;
         var next = inst.BuildSectionEntryPending(nextPos);
         inst.QueuePosition = next.QueuePosition;
         inst.PendingAction = next;
         await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
 
-        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(connection.Player!, GridFightSyncKind.PendingAdvance, (ackPos, next.QueuePosition)));
-        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(connection.Player!, GridFightSyncKind.RefreshShop));
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(
+            connection.Player!, GridFightSyncKind.PendingAdvance, (ackPos, next.QueuePosition)));
     }
 
     private static GridFightSyncUpdateResultScNotify BuildEliteBranchRouteSync(GridFightInstance inst)
@@ -288,13 +462,9 @@ public static class GridFightPendingActionProcessor
         inst.QueuePosition = nextPos;
         inst.PendingAction = null;
         await connection.SendPacket(new PacketGridFightHandlePendingActionScRsp(ackPos));
-        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(connection.Player!, GridFightSyncKind.PendingAdvance, (ackPos, nextPos)));
-
-        if (GridFightLevelResolver.IsCombatNode(inst) && inst.LastEliteBranchConsumedSection != inst.SectionId)
-        {
-            var encounter = GridFightLevelResolver.Resolve(inst);
-            inst.ConfigureNextBattle(encounter.StageId, encounter.Monsters.Select(m => m.MonsterId));
-        }
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(
+            connection.Player!.GridFightManager!.BuildReturnPreparationNotify(ackPos)));
+        await GridFightHeadPlayerService.TrySendActivationAsync(connection, inst);
     }
 
     private static async System.Threading.Tasks.Task HandleAugmentReroll(Connection connection, GridFightInstance inst, uint ackPos, uint augmentId)
@@ -346,15 +516,18 @@ public static class GridFightPendingActionProcessor
                 grantedRoleId = pick.AvatarID;
                 grantedComponent = pick.RoleSavedValueList[0];
                 grantedRoleUniqueId = inst.AllocRoleUniqueId();
-                for (uint p = 14; p <= 18; p++)
+                if (inst.TryAllocBenchPos(out var benchPos))
                 {
-                    if (inst.UniqueIdByPos.ContainsKey(p)) continue;
-                    grantedPos = p; break;
+                    grantedPos = benchPos;
+                    inst.RoleByUniqueId[grantedRoleUniqueId] = grantedRoleId;
+                    inst.RoleStarByUniqueId[grantedRoleUniqueId] = 1;
+                    inst.UniqueIdByPos[grantedPos] = grantedRoleUniqueId;
                 }
-                if (grantedPos == 0) grantedPos = 14;
-                inst.RoleByUniqueId[grantedRoleUniqueId] = grantedRoleId;
-                inst.RoleStarByUniqueId[grantedRoleUniqueId] = 1;
-                inst.UniqueIdByPos[grantedPos] = grantedRoleUniqueId;
+                else
+                {
+                    grantedRoleId = 0;
+                    grantedRoleUniqueId = 0;
+                }
             }
         }
 
@@ -458,24 +631,34 @@ public static class GridFightPendingActionProcessor
             (grantedRoleId, grantedEquipId) = inst.CurrentSupplyOffer[pickIndex];
             grantedRoleUniqueId = inst.AllocRoleUniqueId();
             grantedEquipUniqueId = inst.AllocEquipUniqueId();
-            for (uint p = 14; p <= 18; p++)
+            if (inst.TryAllocBenchPos(out var benchPos))
             {
-                if (inst.UniqueIdByPos.ContainsKey(p)) continue;
-                grantedPos = p; break;
+                grantedPos = benchPos;
+                var avatarId = GridFightRoleLookup.ToAvatarId(grantedRoleId);
+                inst.RoleByUniqueId[grantedRoleUniqueId] = avatarId;
+                inst.RoleStarByUniqueId[grantedRoleUniqueId] = 1;
+                inst.UniqueIdByPos[grantedPos] = grantedRoleUniqueId;
+                grantedRoleId = avatarId;
+                inst.Equipments.Add(new GridFightEquipmentInfo
+                {
+                    GridFightEquipmentId = grantedEquipId,
+                    Source = 1,
+                    UniqueId = grantedEquipUniqueId
+                });
             }
-            if (grantedPos == 0) grantedPos = 14;
-            inst.RoleByUniqueId[grantedRoleUniqueId] = grantedRoleId;
-            inst.RoleStarByUniqueId[grantedRoleUniqueId] = 1;
-            inst.UniqueIdByPos[grantedPos] = grantedRoleUniqueId;
-            inst.Equipments.Add(new GridFightEquipmentInfo
+            else
             {
-                GridFightEquipmentId = grantedEquipId,
-                Source = 1,
-                UniqueId = grantedEquipUniqueId
-            });
+                grantedRoleId = 0;
+                grantedRoleUniqueId = 0;
+                grantedEquipId = 0;
+                grantedEquipUniqueId = 0;
+            }
             if (GameData.GridFightRoleBasicInfoData.TryGetValue(grantedRoleId, out var roleExcel)
                 && roleExcel.RoleSavedValueList.Count > 0)
                 grantedComponent = roleExcel.RoleSavedValueList[0];
+            else if (GridFightRoleLookup.TryFind(grantedRoleId, out var roleByAvatar)
+                     && roleByAvatar.RoleSavedValueList.Count > 0)
+                grantedComponent = roleByAvatar.RoleSavedValueList[0];
         }
 
         inst.LastSupplyConsumedSection = inst.SectionId;
@@ -511,6 +694,7 @@ public static class GridFightPendingActionProcessor
                 UniqueId = grantedEquipUniqueId
             });
             equipSec.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItem });
+            GridFightInstance.AppendBattlefieldLayoutSync(equipSec, inst);
             sync.SyncResultDataList.Add(equipSec);
         }
         if (grantedRoleId > 0)

--- a/GameServer/Game/GridFight/Sync/BuyGoodsSyncPayload.cs
+++ b/GameServer/Game/GridFight/Sync/BuyGoodsSyncPayload.cs
@@ -1,0 +1,21 @@
+namespace March7thHoney.GameServer.Game.GridFight.Sync;
+
+/// <summary>
+/// 商店购买后的 sync 附加数据。
+/// </summary>
+public sealed class BuyGoodsSyncPayload
+{
+    public uint RoleId { get; init; }
+    public uint RoleUniqueId { get; init; }
+    public uint Pos { get; init; }
+    public int GoldDelta { get; init; }
+    public List<uint> MergedRemoved { get; init; } = [];
+    public uint MergedKeepUid { get; init; }
+    public uint MergedNewStar { get; init; }
+    public uint ShopIndex { get; init; }
+    public List<GridFightInstance.RoleMergeResult> Merges { get; init; } = [];
+    public List<Proto.GridFightPosInfo> BenchRepositions { get; init; } = [];
+    public bool DuplicateRetry { get; init; }
+    public uint PurchasedAugmentId { get; init; }
+    public uint PurchasedAugmentTargetUniqueId { get; init; }
+}

--- a/GameServer/Game/GridFight/Sync/GridFightBootstrapSyncBuilder.cs
+++ b/GameServer/Game/GridFight/Sync/GridFightBootstrapSyncBuilder.cs
@@ -38,17 +38,7 @@ public static class GridFightBootstrapSyncBuilder
             ShopSyncInfo = new GridFightShopSyncInfo
             {
                 GLIFNMBMMBL = 2,
-                LDEDGOOKHFL = new FJPONJFLOOH
-                {
-                    EDJPMNLLGGB =
-                    {
-                        new MJJEHCBNOKI { MMKNFIFOPPA = 1, FLICPMGFKOK = 100 },
-                        new MJJEHCBNOKI { MMKNFIFOPPA = 2 },
-                        new MJJEHCBNOKI { MMKNFIFOPPA = 3 },
-                        new MJJEHCBNOKI { MMKNFIFOPPA = 4 },
-                        new MJJEHCBNOKI { MMKNFIFOPPA = 5 }
-                    }
-                },
+                LDEDGOOKHFL = GridFightInstance.BuildShopRarityDisplayInfoForLevel(3),
                 ShopGoodsList =
                 {
                     new GridFightShopGoodsInfo { ShopGoodsPrice = 1, RoleGoodsInfo = new GridFightRoleGoodsInfo { RoleId = 1217, RoleStar = 1 } },

--- a/GameServer/Game/GridFight/Sync/GridFightRouteSyncBuilder.cs
+++ b/GameServer/Game/GridFight/Sync/GridFightRouteSyncBuilder.cs
@@ -1,0 +1,29 @@
+using March7thHoney.Proto;
+
+namespace March7thHoney.GameServer.Game.GridFight.Sync;
+
+/// <summary>
+/// Builds route/layer sync payloads for Grid Fight node-map UI.
+/// </summary>
+public static class GridFightRouteSyncBuilder
+{
+    /// <summary>
+    /// Creates a sync notify that refreshes the current chapter route layer on the client.
+    /// </summary>
+    public static GridFightSyncUpdateResultScNotify BuildLevelLayerSync(GridFightInstance inst)
+    {
+        var notify = new GridFightSyncUpdateResultScNotify();
+        var section = new GridFightSyncResultData();
+        section.UpdateDynamicList.Add(new GridFightSyncData
+        {
+            LevelSyncInfo = new GridFightLevelSyncInfo
+            {
+                DCPKPNLKGMM = inst.CurrentChapterId,
+                SectionId = inst.SectionId,
+                GridFightLayerInfo = inst.BuildCurrentLayerInfo()
+            }
+        });
+        notify.SyncResultDataList.Add(section);
+        return notify;
+    }
+}

--- a/GameServer/Game/GridFight/Sync/GridFightSyncKind.cs
+++ b/GameServer/Game/GridFight/Sync/GridFightSyncKind.cs
@@ -13,4 +13,6 @@ public static class GridFightSyncKind
     public const int PostBattle = 7;
     public const int NoOp = 8;
     public const int PreSettle = 9;
+    public const int Preparation = 10;
+    public const int PosUpdate = 11;
 }

--- a/GameServer/Game/GridFight/Sync/PosUpdateSyncPayload.cs
+++ b/GameServer/Game/GridFight/Sync/PosUpdateSyncPayload.cs
@@ -1,0 +1,10 @@
+namespace March7thHoney.GameServer.Game.GridFight.Sync;
+
+/// <summary>
+/// 走位后的 sync 附加数据。
+/// </summary>
+public sealed class PosUpdateSyncPayload
+{
+    public List<Proto.GridFightPosInfo> UpdatedPosList { get; init; } = [];
+    public List<GridFightInstance.RoleMergeResult> Merges { get; init; } = [];
+}

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightBackToPrepareReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightBackToPrepareReq.cs
@@ -1,3 +1,4 @@
+using March7thHoney.GameServer.Game.GridFight.Battle;
 using March7thHoney.GameServer.Game.GridFight.Sync;
 using March7thHoney.GameServer.Game.GridFight;
 using March7thHoney.GameServer.Server.Packet.Send.GridFight;
@@ -25,10 +26,15 @@ public class HandlerGridFightBackToPrepareReq : Handler
 
         await connection.SendPacket(new PacketGDMIIBNJJEJ());
 
-        
         if (inst.PendingAction?.ReturnPreparationAction == null)
         {
-            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, GridFightSyncKind.NoOp));
+            if (GridFightLevelResolver.IsCombatNode(inst) && inst.NeedsBattleEncounterConfiguration())
+            {
+                var encounter = GridFightLevelResolver.Resolve(inst);
+                inst.ConfigureNextBattle(encounter.StageId, encounter.Monsters.Select(m => m.MonsterId));
+            }
+
+            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, GridFightSyncKind.Preparation));
             return;
         }
 

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightBuyGoodsCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightBuyGoodsCsReq.cs
@@ -14,12 +14,42 @@ public class HandlerGridFightBuyGoodsCsReq : Handler
         var req = GridFightBuyGoodsCsReq.Parser.ParseFrom(data);
         var player = connection.Player!;
         var service = new GridFightService(player);
-        var (roleId, roleUniqueId, pos, goldDelta, mergedRemoved, mergedKeepUid, mergedNewStar) = service.BuyGoods(req.BuyGoodsIndexList);
+        var (roleId, roleUniqueId, pos, goldDelta, merges, benchMoved, duplicateRetry, purchasedAugmentId, purchasedAugmentTargetUniqueId, retcode) = service.BuyGoods(req.BuyGoodsIndexList);
+
+        var shopIndex = req.BuyGoodsIndexList.Count > 0 ? req.BuyGoodsIndexList[0] : 0u;
+        if (retcode == Retcode.RetSucc)
+        {
+            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, GridFightSyncKind.BuyGoods,
+                new BuyGoodsSyncPayload
+                {
+                    RoleId = roleId,
+                    RoleUniqueId = roleUniqueId,
+                    Pos = pos,
+                    GoldDelta = goldDelta,
+                    MergedRemoved = merges.SelectMany(m => m.RemovedUniqueIds).ToList(),
+                    MergedKeepUid = merges.Count > 0 ? merges[^1].KeptUniqueId : 0,
+                    MergedNewStar = merges.Count > 0 ? merges[^1].NewStar : 0,
+                    ShopIndex = shopIndex,
+                    Merges = merges,
+                    BenchRepositions = benchMoved,
+                    DuplicateRetry = duplicateRetry,
+                    PurchasedAugmentId = purchasedAugmentId,
+                    PurchasedAugmentTargetUniqueId = purchasedAugmentTargetUniqueId
+                }));
+
+            await GridFightMergeSyncHelper.SendMergeSyncsAsync(
+                connection,
+                player,
+                merges,
+                GridFightUpdateSrcType.LnpfefkjdhpKkpbagfhpbb);
+
+            var instAfterMerge = player.GridFightManager?.GridFightInstance;
+            if (instAfterMerge != null)
+                await GridFightHeadPlayerService.TrySendActivationAsync(connection, instAfterMerge);
+        }
 
         var rsp = new BasePacket((ushort)CmdIds.CEFIMADBIBH);
-        rsp.SetData(new CEFIMADBIBH());
+        rsp.SetData(new CEFIMADBIBH { Retcode = (uint)retcode });
         await connection.SendPacket(rsp);
-        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, GridFightSyncKind.BuyGoods,
-            (roleId, roleUniqueId, pos, goldDelta, mergedRemoved, mergedKeepUid, mergedNewStar)));
     }
 }

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightEnterBattleStageCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightEnterBattleStageCsReq.cs
@@ -1,5 +1,6 @@
 using March7thHoney.GameServer.Server.Packet.Send.GridFight;
 using March7thHoney.GameServer.Game.Battle;
+using March7thHoney.GameServer.Game.GridFight;
 using March7thHoney.GameServer.Game.GridFight.Battle;
 using March7thHoney.Kcp;
 using March7thHoney.Proto;
@@ -23,9 +24,20 @@ public class HandlerGridFightEnterBattleStageCsReq : Handler
                 await connection.SendPacket(new PacketGridFightEnterBattleStageScRsp(inst, null));
                 return;
             }
+
+            EnsureBattleEncounterConfigured(inst);
             battle = inst.StartBattle();
             await connection.SendPacket(new PacketGridFightSeasonHandBookNotify(inst.BuildHandbookNotifyForBattle()));
         }
         await connection.SendPacket(new PacketGridFightEnterBattleStageScRsp(inst, battle));
+    }
+
+    private static void EnsureBattleEncounterConfigured(GridFightInstance inst)
+    {
+        if (!inst.NeedsBattleEncounterConfiguration())
+            return;
+
+        var encounter = GridFightLevelResolver.Resolve(inst);
+        inst.ConfigureNextBattle(encounter.StageId, encounter.Monsters.Select(m => m.MonsterId));
     }
 }

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightGetDataPostSyncCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightGetDataPostSyncCsReq.cs
@@ -1,0 +1,32 @@
+using March7thHoney.GameServer.Game.GridFight.Battle;
+using March7thHoney.GameServer.Game.GridFight.Sync;
+using March7thHoney.GameServer.Server.Packet.Send.GridFight;
+using March7thHoney.Kcp;
+
+namespace March7thHoney.GameServer.Server.Packet.Recv.GridFight;
+
+/// <summary>
+/// Handles the post-GetData sync request the client sends right after GridFightGetDataCsReq.
+/// </summary>
+[Opcode(CmdIds.GridFightGetDataPostSyncCsReq)]
+public class HandlerGridFightGetDataPostSyncCsReq : Handler
+{
+    public override async Task OnHandle(Connection connection, byte[] header, byte[] data)
+    {
+        await connection.SendPacket(new PacketGridFightGetDataPostSyncScRsp());
+
+        var inst = connection.Player?.GridFightManager?.GridFightInstance;
+        if (inst == null)
+            return;
+
+        inst.EnsureRouteBinding();
+        if (inst.BattleComponent.StageId == 0 && GridFightLevelResolver.IsCombatNode(inst))
+        {
+            var encounter = GridFightLevelResolver.Resolve(inst);
+            inst.ConfigureNextBattle(encounter.StageId, encounter.Monsters.Select(m => m.MonsterId));
+        }
+
+        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(
+            GridFightRouteSyncBuilder.BuildLevelLayerSync(inst)));
+    }
+}

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightMiscCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightMiscCsReq.cs
@@ -65,11 +65,13 @@ public class HandlerGridFightEquipDressCsReq : Handler
             var addItem = new GridFightGameItemSyncInfo();
             addItem.GridFightEquipmentList.Add(craftedAdvancedEquip.Added);
             craftSec.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItem });
+            GridFightInstance.AppendBattlefieldLayoutSync(craftSec, inst);
             sync.SyncResultDataList.Add(craftSec);
         }
 
         var sec = new GridFightSyncResultData();
         sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = roleInfo });
+        GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
         sync.SyncResultDataList.Add(sec);
         await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
     }
@@ -162,6 +164,7 @@ public class HandlerGridFightEquipCraftCsReq : Handler
         var addItem = new GridFightGameItemSyncInfo();
         addItem.GridFightEquipmentList.Add(crafted);
         sec.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItem });
+        GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
 
         sync.SyncResultDataList.Add(sec);
         sync.SyncResultDataList.Add(new GridFightSyncResultData());
@@ -284,6 +287,7 @@ public class HandlerGridFightUseConsumableCsReq : Handler
         var addItem = new GridFightGameItemSyncInfo();
         addItem.GridFightEquipmentList.Add(added);
         sec.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItem });
+        GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
     }
 
     private static GridGameRoleInfo BuildRoleInfoSnapshot(GridFightInstance inst, uint roleUid, uint roleId)
@@ -359,6 +363,7 @@ public class HandlerGridFightUseOrbCsReq : Handler
                     UniqueId = r.AddEquipmentUniqueId.Value
                 });
                 sec.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = item });
+                GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
             }
 
             if (r.AddConsumableItemId.HasValue)
@@ -409,7 +414,11 @@ public class HandlerGridFightUseOrbCsReq : Handler
                 }
             });
             lvlSec.UpdateDynamicList.Add(new GridFightSyncData { GridFightBuyExpCost = inst.GetBuyExpCost() });
-            lvlSec.UpdateDynamicList.Add(new GridFightSyncData { MaxBattleRoleNum = inst.GetCurrentMaxBattleRoleNum() });
+            GridFightInstance.AppendBattlefieldLayoutSync(lvlSec, inst);
+            lvlSec.UpdateDynamicList.Add(new GridFightSyncData
+            {
+                ShopSyncInfo = new GridFightShopSyncInfo { LDEDGOOKHFL = inst.BuildShopRarityDisplayInfo() }
+            });
             sync.SyncResultDataList.Add(lvlSec);
         }
 

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightMiscCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightMiscCsReq.cs
@@ -186,6 +186,8 @@ public class HandlerGridFightUseConsumableCsReq : Handler
 
         var itemId = req.ItemId;
         if (!GameData.GridFightConsumablesData.TryGetValue(itemId, out var consumable)) return;
+        if (consumable.IfConsume && inst.Consumables.All(c => c.ItemId != itemId || c.Num == 0))
+            return;
 
         var sync = new GridFightSyncUpdateResultScNotify();
         var sec = new GridFightSyncResultData { GridUpdateSrc = GridFightUpdateSrcType.LnpfefkjdhpNefkflkampo };
@@ -195,6 +197,17 @@ public class HandlerGridFightUseConsumableCsReq : Handler
         
         
         
+        var target = req.DisplayValue;
+        var ruleApplied = consumable.ConsumableRule switch
+        {
+            Enums.GridFight.GridFightConsumeTypeEnum.Remove => ApplyRemoveRule(inst, target, sec),
+            Enums.GridFight.GridFightConsumeTypeEnum.Roll => ApplyRollRule(inst, target, sec),
+            Enums.GridFight.GridFightConsumeTypeEnum.Upgrade => ApplyUpgradeRule(inst, target, sec),
+            _ => false
+        };
+        if (!ruleApplied)
+            return;
+
         if (consumable.IfConsume)
         {
             var current = inst.Consumables.FirstOrDefault(c => c.ItemId == itemId);
@@ -212,73 +225,106 @@ public class HandlerGridFightUseConsumableCsReq : Handler
             sec.UpdateDynamicList.Add(remaining > 0
                 ? new GridFightSyncData { UpdateGameItemInfo = payload }
                 : new GridFightSyncData { RemoveGameItemInfo = payload });
+            inst.TryConsumeConsumable(itemId);
         }
-
-        var target = req.DisplayValue;
-        switch (consumable.ConsumableRule)
-        {
-            case Enums.GridFight.GridFightConsumeTypeEnum.Remove:
-                HandleRemoveRule(inst, target, sec);
-                break;
-            case Enums.GridFight.GridFightConsumeTypeEnum.Roll:
-                HandleRollRule(inst, target, sec);
-                break;
-            default:
-                
-                break;
-        }
-
-        if (consumable.IfConsume) inst.TryConsumeConsumable(itemId);
 
         sync.SyncResultDataList.Add(sec);
         sync.SyncResultDataList.Add(new GridFightSyncResultData());
         await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
     }
 
-    
-    private static void HandleRemoveRule(GridFightInstance inst, GridFightConsumableTargetInfo target, GridFightSyncResultData sec)
+    /// <summary>
+    /// 拆卸类消耗品：卸下目标角色全部装备。
+    /// </summary>
+    private static bool ApplyRemoveRule(GridFightInstance inst, GridFightConsumableTargetInfo target, GridFightSyncResultData sec)
     {
-        if (target?.RemoveTypeTargetInfo == null) return;
+        if (target?.RemoveTypeTargetInfo == null) return false;
         var roleUid = target.RemoveTypeTargetInfo.DressRoleUniqueId;
-        if (!inst.RoleByUniqueId.TryGetValue(roleUid, out var roleId)) return;
+        if (!inst.RoleByUniqueId.TryGetValue(roleUid, out var roleId)) return false;
         inst.UnequipAllFromRole(roleUid);
         sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = BuildRoleInfoSnapshot(inst, roleUid, roleId) });
+        return true;
     }
 
-    
-    private static void HandleRollRule(GridFightInstance inst, GridFightConsumableTargetInfo target, GridFightSyncResultData sec)
+    /// <summary>
+    /// 重铸类消耗品：随机替换装备或角色全身装备。
+    /// </summary>
+    private static bool ApplyRollRule(GridFightInstance inst, GridFightConsumableTargetInfo target, GridFightSyncResultData sec)
     {
-        if (target?.RollTypeTargetInfo == null) return;
+        if (target?.RollTypeTargetInfo == null) return false;
         var equipUid = target.RollTypeTargetInfo.DressEquipmentUniqueId;
         var roleUid = target.RollTypeTargetInfo.DressRoleUniqueId;
 
         if (equipUid != 0)
-        {
-            RollOneEquipment(inst, equipUid, sec);
-            return;
-        }
+            return RollOneEquipment(inst, equipUid, sec);
 
-        if (roleUid != 0 && inst.RoleByUniqueId.TryGetValue(roleUid, out var roleId))
-        {
-            
-            var equips = inst.EquipUniqueIdsByRoleUniqueId.TryGetValue(roleUid, out var list)
-                ? list.ToList()
-                : new List<uint>();
-            foreach (var uid in equips)
-                RollOneEquipment(inst, uid, sec);
-            sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = BuildRoleInfoSnapshot(inst, roleUid, roleId) });
-        }
+        if (roleUid == 0 || !inst.RoleByUniqueId.TryGetValue(roleUid, out var roleId))
+            return false;
+
+        var equips = inst.EquipUniqueIdsByRoleUniqueId.TryGetValue(roleUid, out var list)
+            ? list.ToList()
+            : new List<uint>();
+        if (equips.Count == 0) return false;
+
+        var rolledAny = false;
+        foreach (var uid in equips)
+            rolledAny |= RollOneEquipment(inst, uid, sec);
+        if (!rolledAny) return false;
+
+        sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = BuildRoleInfoSnapshot(inst, roleUid, roleId) });
+        return true;
     }
 
-    private static void RollOneEquipment(GridFightInstance inst, uint equipUid, GridFightSyncResultData sec)
+    /// <summary>
+    /// 升级类消耗品（如特权赋予卡 350104）：将 3503**** 成品装备升级为 3504****。
+    /// </summary>
+    private static bool ApplyUpgradeRule(GridFightInstance inst, GridFightConsumableTargetInfo target, GridFightSyncResultData sec)
+    {
+        if (target?.UpgradeTypeTargetInfo == null) return false;
+        var equipUid = target.UpgradeTypeTargetInfo.DressEquipmentUniqueId;
+        if (equipUid == 0) return false;
+
+        var old = inst.FindEquipment(equipUid);
+        if (old == null) return false;
+
+        uint? wearer = null;
+        var roleId = 0u;
+        foreach (var (roleUid, equipList) in inst.EquipUniqueIdsByRoleUniqueId)
+        {
+            if (!equipList.Contains(equipUid)) continue;
+            wearer = roleUid;
+            inst.RoleByUniqueId.TryGetValue(roleUid, out roleId);
+            break;
+        }
+
+        var oldClone = old.Clone();
+        var upgraded = inst.UpgradeCraftableEquipment(equipUid);
+        if (upgraded == null) return false;
+
+        var removeItem = new GridFightGameItemSyncInfo();
+        removeItem.GridFightEquipmentList.Add(oldClone);
+        sec.UpdateDynamicList.Add(new GridFightSyncData { RemoveGameItemInfo = removeItem });
+
+        var addItem = new GridFightGameItemSyncInfo();
+        addItem.GridFightEquipmentList.Add(upgraded);
+        sec.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItem });
+
+        if (wearer.HasValue && roleId != 0)
+            sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = BuildRoleInfoSnapshot(inst, wearer.Value, roleId) });
+
+        GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
+        return true;
+    }
+
+    private static bool RollOneEquipment(GridFightInstance inst, uint equipUid, GridFightSyncResultData sec)
     {
         var old = inst.FindEquipment(equipUid);
-        if (old == null) return;
+        if (old == null) return false;
         var newId = GridFightInstance.RollSameCategoryEquipment(old.GridFightEquipmentId);
-        if (newId == 0) return;
+        if (newId == 0) return false;
         var oldClone = old.Clone();
         var added = inst.RollEquipment(equipUid, newId, source: 1);
-        if (added == null) return;
+        if (added == null) return false;
 
         var removeItem = new GridFightGameItemSyncInfo();
         removeItem.GridFightEquipmentList.Add(oldClone);
@@ -288,6 +334,7 @@ public class HandlerGridFightUseConsumableCsReq : Handler
         addItem.GridFightEquipmentList.Add(added);
         sec.UpdateDynamicList.Add(new GridFightSyncData { AddGameItemInfo = addItem });
         GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
+        return true;
     }
 
     private static GridGameRoleInfo BuildRoleInfoSnapshot(GridFightInstance inst, uint roleUid, uint roleId)

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightMiscCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightMiscCsReq.cs
@@ -1,4 +1,6 @@
 using March7thHoney.Data;
+using March7thHoney.Data.Excel;
+using March7thHoney.GameServer.Game.GridFight.Battle;
 using March7thHoney.GameServer.Game.GridFight.Sync;
 using March7thHoney.GameServer.Game.GridFight;
 using March7thHoney.GameServer.Server.Packet.Send.GridFight;
@@ -198,11 +200,13 @@ public class HandlerGridFightUseConsumableCsReq : Handler
         
         
         var target = req.DisplayValue;
+        List<GridFightInstance.RoleMergeResult>? copyMerges = null;
         var ruleApplied = consumable.ConsumableRule switch
         {
             Enums.GridFight.GridFightConsumeTypeEnum.Remove => ApplyRemoveRule(inst, target, sec),
             Enums.GridFight.GridFightConsumeTypeEnum.Roll => ApplyRollRule(inst, target, sec),
             Enums.GridFight.GridFightConsumeTypeEnum.Upgrade => ApplyUpgradeRule(inst, target, sec),
+            Enums.GridFight.GridFightConsumeTypeEnum.Copy => ApplyCopyRule(inst, consumable, target, sec, out copyMerges),
             _ => false
         };
         if (!ruleApplied)
@@ -231,6 +235,15 @@ public class HandlerGridFightUseConsumableCsReq : Handler
         sync.SyncResultDataList.Add(sec);
         sync.SyncResultDataList.Add(new GridFightSyncResultData());
         await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(sync));
+
+        if (copyMerges is { Count: > 0 })
+        {
+            await GridFightMergeSyncHelper.SendMergeSyncsAsync(
+                connection,
+                player,
+                copyMerges,
+                GridFightUpdateSrcType.LnpfefkjdhpNefkflkampo);
+        }
     }
 
     /// <summary>
@@ -311,6 +324,63 @@ public class HandlerGridFightUseConsumableCsReq : Handler
 
         if (wearer.HasValue && roleId != 0)
             sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = BuildRoleInfoSnapshot(inst, wearer.Value, roleId) });
+
+        GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
+        return true;
+    }
+
+    /// <summary>
+    /// 投影仪类消耗品（350105/350106）：复制 1 星形态至购买落点；刷新源槽位，避免客户端覆盖原角色。
+    /// </summary>
+    private static bool ApplyCopyRule(
+        GridFightInstance inst,
+        GridFightConsumablesExcel consumable,
+        GridFightConsumableTargetInfo target,
+        GridFightSyncResultData sec,
+        out List<GridFightInstance.RoleMergeResult> merges)
+    {
+        merges = [];
+        if (target?.CopyTypeTargetInfo == null) return false;
+
+        var sourceUid = target.CopyTypeTargetInfo.DressRoleUniqueId;
+        if (sourceUid == 0) return false;
+
+        var maxRarity = consumable.ConsumableParamList.Count > 0 ? consumable.ConsumableParamList[0] : 5u;
+        var (ok, newUid, targetPos, sourcePos, _) = inst.TryCopyRole(sourceUid, maxRarity);
+        if (!ok || newUid == 0) return false;
+
+        sec.SyncEffectParamList.Add(sourcePos);
+        sec.SyncEffectParamList.Add(targetPos);
+
+        var copyCtx = new CMCJNKPKBEM();
+        copyCtx.CFNPGNMPNDN[sourceUid.ToString()] = sourcePos;
+        copyCtx.CFNPGNMPNDN[newUid.ToString()] = targetPos;
+        sec.UpdateDynamicList.Add(new GridFightSyncData { CFNPGNMPNDN = copyCtx });
+
+        var addInfo = inst.BuildGridGameRoleInfo(newUid, targetPos);
+        addInfo.RoleStar = 1;
+        sec.UpdateDynamicList.Add(new GridFightSyncData { AddRoleInfo = addInfo });
+
+        if (inst.RoleByUniqueId.TryGetValue(sourceUid, out var sourceRoleKey))
+        {
+            sec.UpdateDynamicList.Add(new GridFightSyncData
+            {
+                UpdateRoleInfo = BuildRoleInfoSnapshot(
+                    inst,
+                    sourceUid,
+                    GridFightRoleLookup.ToSyncRoleId(sourceRoleKey))
+            });
+        }
+
+        merges = inst.TryAutoMergeAllRoles();
+        var benchMoved = merges.Count > 0 ? inst.FinalizeBenchAfterMerge() : [];
+
+        foreach (var benchPos in benchMoved)
+        {
+            var roleInfo = GridFightManager.TryBuildBenchRepositionRoleInfo(inst, benchPos, merges);
+            if (roleInfo == null) continue;
+            sec.UpdateDynamicList.Add(new GridFightSyncData { UpdateRoleInfo = roleInfo });
+        }
 
         GridFightInstance.AppendBattlefieldLayoutSync(sec, inst);
         return true;

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightResumeGamePlayCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightResumeGamePlayCsReq.cs
@@ -18,6 +18,9 @@ public class HandlerGridFightResumeGamePlayCsReq : Handler
 
         await connection.SendPacket(new PacketKMDHLENLIMF());
         await connection.SendPacket(new PacketINHDFEIOBNK(player));
-        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, GridFightSyncKind.Bootstrap));
+
+        var inst = player.GridFightManager!.GridFightInstance!;
+        if (inst.InitialBenchRolesSynced)
+            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, GridFightSyncKind.Bootstrap));
     }
 }

--- a/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightUpdatePosCsReq.cs
+++ b/GameServer/Server/Packet/Recv/GridFight/HandlerGridFightUpdatePosCsReq.cs
@@ -1,4 +1,5 @@
 using March7thHoney.GameServer.Game.GridFight;
+using March7thHoney.GameServer.Game.GridFight.Sync;
 using March7thHoney.GameServer.Server.Packet.Send.GridFight;
 using March7thHoney.Kcp;
 using March7thHoney.Proto;
@@ -15,13 +16,36 @@ public class HandlerGridFightUpdatePosCsReq : Handler
         var service = new GridFightService(player);
         if (service.Current == null)
         {
-            await connection.SendPacket(new PacketGridFightUpdatePosScRsp());
+            await connection.SendPacket(new PacketGridFightUpdatePosScRsp(Retcode.RetGridFightNotInGameplay));
             return;
         }
 
-        var posList = service.UpdatePos(req.GridFightPosInfoList);
+        var (posList, retcode, merges, syncPosList) = service.UpdatePos(req.GridFightPosInfoList);
 
-        await connection.SendPacket(new PacketGridFightUpdatePosScRsp(posList));
-        await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, posList));
+        await connection.SendPacket(new PacketGridFightUpdatePosScRsp(retcode, retcode == Retcode.RetSucc ? posList : null));
+        if (retcode == Retcode.RetSucc)
+        {
+            await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(player, GridFightSyncKind.PosUpdate,
+                new PosUpdateSyncPayload
+                {
+                    UpdatedPosList = syncPosList,
+                    Merges = merges
+                }));
+
+            await GridFightMergeSyncHelper.SendMergeSyncsAsync(
+                connection,
+                player,
+                merges,
+                GridFightUpdateSrcType.LnpfefkjdhpMhncgoehmch);
+
+            var inst = service.Current!;
+            if (GridFightCyreneSpecialShopService.TryApplySpecialShop(inst))
+            {
+                await connection.SendPacket(new PacketGridFightSyncUpdateResultScNotify(
+                    player.GridFightManager!.BuildShopRefreshNotify(1)));
+            }
+
+            await GridFightHeadPlayerService.TrySendActivationAsync(connection, inst);
+        }
     }
 }

--- a/GameServer/Server/Packet/Send/GridFight/PacketGridFightEnterBattleStageScRsp.cs
+++ b/GameServer/Server/Packet/Send/GridFight/PacketGridFightEnterBattleStageScRsp.cs
@@ -17,7 +17,10 @@ public class PacketGridFightEnterBattleStageScRsp : BasePacket
         if (inst == null || battle == null)
             proto.Retcode = (uint)Retcode.RetFail;
         else
+        {
+            proto.Retcode = (uint)Retcode.RetSucc;
             proto.BattleInfo = BuildBattleInfo(inst, battle);
+        }
         SetData(proto);
     }
 
@@ -44,7 +47,7 @@ public class PacketGridFightEnterBattleStageScRsp : BasePacket
             {
                 BNLHIMHFGDK = 1,
                 DCPKPNLKGMM = inst.CurrentChapterId,
-                NDOCIKPLKIF = inst.NDOCIKPLKIF,
+                NDOCIKPLKIF = inst.ResolveEliteGroupForCurrentSection(),
                 SectionId = inst.SectionId
             }
         };
@@ -56,24 +59,32 @@ public class PacketGridFightEnterBattleStageScRsp : BasePacket
         foreach (var portalBuffId in inst.ActivePortalBuffIds)
             info.AFCMOOFGBPK.GridFightPortalBuffList.Add(new MMDJJDEJMMN { PortalBuffId = portalBuffId });
 
-        foreach (var (roleId, _) in inst.UniqueIdByPos
+        foreach (var (roleKey, _) in inst.UniqueIdByPos
                      .OrderBy(kv => kv.Key)
                      .Where(kv => kv.Key > 0 && kv.Key <= 13 && kv.Value != 0 && inst.RoleByUniqueId.ContainsKey(kv.Value))
-                     .Select(kv => (RoleId: inst.RoleByUniqueId[kv.Value], Pos: kv.Key)))
+                     .Select(kv => (RoleKey: inst.RoleByUniqueId[kv.Value], Pos: kv.Key)))
         {
-            if (!GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var basicInfo)) continue;
+            var basicInfo = GridFightRoleLookup.Find(roleKey);
+            if (basicInfo == null) continue;
             foreach (var savedValue in basicInfo.RoleSavedValueList)
                 info.AFCMOOFGBPK.OGHGLMGJGEM[savedValue] = 0;
         }
         var player = battle.Player;
         var collection = new PlayerDataCollection(player.Data, player.InventoryManager!.Data, battle.Lineup);
-        foreach (var (roleId, _) in inst.ResolveBackgroundRoles())
+        foreach (var (roleKey, pos) in inst.ResolveBackgroundRoles())
         {
-            var resolved = GridFightBattleProtoBuilder.ResolveBattleAvatar(player, roleId);
+            var resolved = GridFightBattleProtoBuilder.ResolveBackgroundBattleAvatar(player, roleKey);
             var avatar = resolved.Avatar;
             if (avatar == null) continue;
-            var ba = avatar.ToBattleProto(collection, resolved.AvatarType);
-            ba.Id = (uint)(GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var bi) ? bi.AvatarID : roleId);
+            var ba = avatar.ToBattleProto(collection, AvatarType.AvatarGridFightType);
+            ba.Id = GridFightRoleLookup.ToAvatarId(roleKey);
+            ba.Index = pos;
+            if (ba.Level < 80)
+            {
+                ba.Level = 80;
+                ba.Promotion = 6;
+            }
+
             info.AFCMOOFGBPK.PIDIGFGKAMK.Add(ba);
         }
 
@@ -83,18 +94,21 @@ public class PacketGridFightEnterBattleStageScRsp : BasePacket
         foreach (var (pos, uniqueId) in inst.UniqueIdByPos.OrderBy(kv => kv.Key))
         {
             if (pos == 0 || pos > 13) continue;
-            if (uniqueId == 0 || !inst.RoleByUniqueId.TryGetValue(uniqueId, out var roleId)) continue;
-            var avatarId = GameData.GridFightRoleBasicInfoData.TryGetValue(roleId, out var bi) ? bi.AvatarID : roleId;
+            if (uniqueId == 0 || !inst.RoleByUniqueId.TryGetValue(uniqueId, out var roleKey)) continue;
+            var basicInfo = GridFightRoleLookup.Find(roleKey);
 
+            var boundAugmentId = inst.GetPrimaryRoleAugmentId(uniqueId);
             var roleInfo = new JAJOBJJPINN
             {
-                RoleId = roleId,
-                AvatarId = avatarId,
+                RoleId = basicInfo?.ID ?? roleKey,
+                AvatarId = basicInfo?.AvatarID ?? roleKey,
                 Pos = pos,
                 UniqueId = uniqueId,
                 RoleStar = inst.RoleStarByUniqueId.GetValueOrDefault(uniqueId, 1u),
                 GJEHIGGNIAP = new IFDFHPAMHCL()
             };
+            if (boundAugmentId > 0)
+                roleInfo.GJEHIGGNIAP.KKMBLCJHAHK = boundAugmentId;
             roleInfo.ConvertPropertyToFixpoint.Add(32, 180);
             roleInfo.ConvertPropertyToFixpoint.Add(33, 480);
             roleInfo.ConvertPropertyToFixpoint.Add(34, 440);
@@ -124,6 +138,12 @@ public class PacketGridFightEnterBattleStageScRsp : BasePacket
             }
 
             info.AFCMOOFGBPK.GridGameRoleList.Add(roleInfo);
+
+            if (inst.RoleAugmentIdsByUniqueId.TryGetValue(uniqueId, out var roleAugments))
+            {
+                foreach (var augmentId in roleAugments)
+                    info.AFCMOOFGBPK.MMAJCLACOBN.Add(inst.BuildBattleRoleAugmentBinding(uniqueId, augmentId, pos));
+            }
         }
 
         return info;

--- a/GameServer/Server/Packet/Send/GridFight/PacketGridFightGetDataPostSyncScRsp.cs
+++ b/GameServer/Server/Packet/Send/GridFight/PacketGridFightGetDataPostSyncScRsp.cs
@@ -1,0 +1,15 @@
+using March7thHoney.Kcp;
+using March7thHoney.Proto;
+
+namespace March7thHoney.GameServer.Server.Packet.Send.GridFight;
+
+/// <summary>
+/// Acknowledges GridFightGetDataPostSyncCsReq so the client can continue loading gameplay UI.
+/// </summary>
+public class PacketGridFightGetDataPostSyncScRsp : BasePacket
+{
+    public PacketGridFightGetDataPostSyncScRsp() : base(CmdIds.GridFightGetDataPostSyncScRsp)
+    {
+        SetData(new KMDHLENLIMF { Retcode = (uint)Retcode.RetSucc });
+    }
+}

--- a/GameServer/Server/Packet/Send/GridFight/PacketGridFightUpdatePosScRsp.cs
+++ b/GameServer/Server/Packet/Send/GridFight/PacketGridFightUpdatePosScRsp.cs
@@ -5,9 +5,13 @@ namespace March7thHoney.GameServer.Server.Packet.Send.GridFight;
 
 public class PacketGridFightUpdatePosScRsp : BasePacket
 {
-    public PacketGridFightUpdatePosScRsp(IEnumerable<GridFightPosInfo>? posInfoList = null) : base(CmdIds.GridFightUpdatePosScRsp)
+    /// <summary>
+    /// 返回走位结果；retcode 非 0 时 posInfoList 为空。
+    /// </summary>
+    public PacketGridFightUpdatePosScRsp(Retcode retcode, IEnumerable<GridFightPosInfo>? posInfoList = null)
+        : base(CmdIds.GridFightUpdatePosScRsp)
     {
-        var proto = new GridFightUpdatePosScRsp();
+        var proto = new GridFightUpdatePosScRsp { Retcode = (uint)retcode };
         if (posInfoList != null)
             proto.GridFightPosInfoList.AddRange(posInfoList);
         SetData(proto);

--- a/KcpSharp/CmdIds.cs
+++ b/KcpSharp/CmdIds.cs
@@ -803,6 +803,8 @@ public class CmdIds
     public const int AKHODIIOGDJ = 8466;
     public const int KMOFOOGIDOP = 8610;
     public const int GridFightBuyExpCsReq = 8708;
+    public const int GridFightGetDataPostSyncCsReq = 8707;
+    public const int GridFightGetDataPostSyncScRsp = 8704;
     public const int DJCHCHCAJPB = 8509;
     public const int GridFightRefreshShopCsReq = 8660;
     public const int CMJCEEDCIAN = 8658;

--- a/WebServer/dotnet-tools.json
+++ b/WebServer/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-ef": {
+      "version": "10.0.8",
+      "commands": [
+        "dotnet-ef"
+      ],
+      "rollForward": false
+    }
+  }
+}


### PR DESCRIPTION
- 修复角色升星逻辑（布洛妮娅除外，她有两个ID），目前可以正常追三星五费
- 修复出战角色列表，现在可以正常出战
- 修复商店排除已有三星
- 修复商店概率显示
- 修复看不见的格子占用
- 商店购买时同步席位
- 刷新商店时更新角色池
- 添加特性：开局无条件开放13出战席
- 添加特性：三星昔涟触发诗篇商店（但是没有用）
- 添加特性：任意狼尊触发头号玩家（还是没有用，无法触发GM控制台）